### PR TITLE
Pin go patch version

### DIFF
--- a/.github/workflows/test-and-lint.yaml
+++ b/.github/workflows/test-and-lint.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.22
+          - 1.22.4
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.22
+          - 1.22.4
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.22
+          - 1.22.4
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -77,7 +77,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.22
+          - 1.22.4
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22 as builder
+FROM golang:1.22.4 as builder
 WORKDIR /app
 COPY . ./
 RUN make build


### PR DESCRIPTION
As github actions assume that 1.22 is 1.22.3,
this will make the wanted go version more precise.