### PR TITLE
Bump go version to 1.22.5

### DIFF
--- a/.github/workflows/test-and-lint.yaml
+++ b/.github/workflows/test-and-lint.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.22.4
+          - 1.22.5
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.22.4
+          - 1.22.5
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.22.4
+          - 1.22.5
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -77,7 +77,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.22.4
+          - 1.22.5
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
 # Copyright 2024 go-dataspace
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     https://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.4 as builder
+FROM golang:1.22.5 as builder
 WORKDIR /app
 COPY . ./
 RUN make build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-dataspace/run-dsp
 
-go 1.22.4
+go 1.22.5
 
 require (
 	github.com/alecthomas/kong v0.9.0


### PR DESCRIPTION
go1.22.5 (released 2024-07-02) includes security fixes to the net/http package, as well as bug fixes to the compiler, cgo, the go command, the linker, the runtime, and the crypto/tls, go/types, net, net/http, and os/exec packages.