### PR TITLE
Add control interface to RUN-DSP.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,8 @@
                 "--provider-address",
                 "127.0.0.1:9090",
                 "--provider-insecure",
+                "--control-enabled",
+                "--control-insecure"
             ]
         }
     ]

--- a/dsp/control/control.go
+++ b/dsp/control/control.go
@@ -1,0 +1,387 @@
+// Copyright 2024 go-dataspace
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package control
+
+import (
+	"context"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/go-dataspace/run-dsp/dsp/shared"
+	"github.com/go-dataspace/run-dsp/dsp/statemachine"
+	"github.com/go-dataspace/run-dsp/internal/constants"
+	"github.com/go-dataspace/run-dsp/jsonld"
+	"github.com/go-dataspace/run-dsp/logging"
+	"github.com/go-dataspace/run-dsp/odrl"
+	dspv1alpha1 "github.com/go-dataspace/run-dsrpc/gen/go/dsp/v1alpha1"
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+var dspaceContext = jsonld.NewRootContext([]jsonld.ContextEntry{{ID: constants.DSPContext}})
+
+type Server struct {
+	dspv1alpha1.ClientServiceServer
+
+	requester  shared.Requester
+	store      statemachine.Archiver
+	reconciler *statemachine.Reconciler
+	provider   dspv1alpha1.ProviderServiceClient
+	selfURL    *url.URL
+}
+
+func New(
+	requester shared.Requester,
+	store statemachine.Archiver,
+	reconciler *statemachine.Reconciler,
+	provider dspv1alpha1.ProviderServiceClient,
+	selfURL *url.URL,
+) *Server {
+	return &Server{
+		requester:  requester,
+		store:      store,
+		reconciler: reconciler,
+		provider:   provider,
+		selfURL:    selfURL,
+	}
+}
+
+func (s *Server) getProviderURL(ctx context.Context, u string) (*url.URL, error) {
+	pu, err := url.Parse(u)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid URL: %s", u)
+	}
+	pu.Path = path.Join(pu.Path, ".well-known", "dspace-version")
+	resp, err := s.requester.SendHTTPRequest(ctx, "GET", pu, nil)
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound, "could not fetch dataspace version url %s: %s", pu.String(), err)
+	}
+
+	wellKnown, err := shared.UnmarshalAndValidate(ctx, resp, shared.VersionResponse{})
+	if err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "Invalid version response: %s", err)
+	}
+
+	for _, v := range wellKnown.ProtocolVersions {
+		if v.Version == constants.DSPVersion {
+			du := shared.MustParseURL(u)
+			du.Path = path.Join(du.Path, v.Path)
+			return du, nil
+		}
+	}
+	return nil, status.Errorf(
+		codes.FailedPrecondition,
+		"provider does not support dataspace protocol version %s", constants.DSPVersion,
+	)
+}
+
+// Ping is a request to test if the provider is working, and to test the auth information.
+func (s *Server) Ping(
+	_ context.Context, _ *dspv1alpha1.ClientServicePingRequest,
+) (*dspv1alpha1.ClientServicePingResponse, error) {
+	return &dspv1alpha1.ClientServicePingResponse{}, nil
+}
+
+// Gets the catalogue based on the query parameters and the authorization header.
+func (s *Server) GetProviderCatalogue(
+	ctx context.Context, req *dspv1alpha1.GetProviderCatalogueRequest,
+) (*dspv1alpha1.GetProviderCatalogueResponse, error) {
+	providerURL, err := s.getProviderURL(ctx, req.ProviderUri)
+	if err != nil {
+		return nil, err
+	}
+
+	providerURL.Path = path.Join(providerURL.Path, "catalog", "request")
+	resp, err := encodeRequestDecode[shared.CatalogRequestMessage, shared.CatalogAcknowledgement](
+		ctx,
+		s.requester,
+		"POST",
+		providerURL,
+		shared.CatalogRequestMessage{
+			Context: dspaceContext,
+			Type:    "dspace:CatalogRequestMessage",
+			Filter:  []any{},
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dspv1alpha1.GetProviderCatalogueResponse{
+		Datasets: processCatalogue(resp.Datasets),
+	}, nil
+}
+
+// Gets information about a single dataset.
+func (s *Server) GetProviderDataset(
+	ctx context.Context, req *dspv1alpha1.GetProviderDatasetRequest,
+) (*dspv1alpha1.GetProviderDatasetResponse, error) {
+	providerURL, err := s.getProviderURL(ctx, req.ProviderUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	id, err := uuid.Parse(req.DatasetId)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Dataset ID is not a valid UUID.")
+	}
+
+	providerURL.Path = path.Join(providerURL.Path, "catalog", "datasets", req.DatasetId)
+	resp, err := encodeRequestDecode[shared.DatasetRequestMessage, shared.Dataset](
+		ctx,
+		s.requester,
+		"GET",
+		providerURL,
+		shared.DatasetRequestMessage{
+			Context: dspaceContext,
+			Type:    "dspace:DatasetRequestMessage",
+			Dataset: id.URN(),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dspv1alpha1.GetProviderDatasetResponse{
+		ProviderUrl: req.ProviderUrl,
+		Dataset:     processDataset(resp),
+	}, err
+}
+
+// Publishes a dataset.
+//
+//nolint:funlen,cyclop
+func (s *Server) GetProviderDatasetDownloadInformation(
+	ctx context.Context, req *dspv1alpha1.GetProviderDatasetDownloadInformationRequest,
+) (*dspv1alpha1.GetProviderDatasetDownloadInformationResponse, error) {
+	providerURL, err := s.getProviderURL(ctx, req.GetProviderUrl())
+	if err != nil {
+		return nil, err
+	}
+
+	datasetID, err := uuid.Parse(req.GetDatasetId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Dataset ID is not a valid UUID.")
+	}
+
+	consumerPID := uuid.New()
+	selfURL := shared.MustParseURL(s.selfURL.String())
+	selfURL.Path = path.Join(selfURL.Path, "callback")
+	ctx, contractInit, err := statemachine.NewContract(
+		ctx,
+		s.store, s.provider, s.reconciler,
+		uuid.UUID{}, consumerPID,
+		statemachine.ContractStates.INITIAL,
+		odrl.Offer{
+			MessageOffer: odrl.MessageOffer{
+				PolicyClass: odrl.PolicyClass{
+					AbstractPolicyRule: odrl.AbstractPolicyRule{},
+					ID:                 uuid.New().URN(),
+				},
+				Type:   "odrl:Offer",
+				Target: datasetID.URN(),
+			},
+		},
+		providerURL,
+		selfURL,
+		statemachine.DataspaceConsumer,
+	)
+	ctx, logger := logging.InjectLabels(ctx, "method", "GetProviderDownloadInformationRequest")
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Couldn't create contract")
+	}
+	apply, err := contractInit.Send(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Couldn't generate inital contract request.")
+	}
+	logger.Debug("Beginning contract negotiation")
+	apply()
+
+	contract, err := s.store.GetConsumerContract(ctx, consumerPID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "could not get consumer contract with PID %s: %s", consumerPID, err)
+	}
+
+	logger.Info("Starting to monitor contract")
+	for contract.GetState() != statemachine.ContractStates.FINALIZED {
+		logger.Info("Contract not finalized", "state", contract.GetState().String())
+		time.Sleep(1 * time.Second)
+		contract, err = s.store.GetConsumerContract(ctx, consumerPID)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "could not get consumer contract with PID %s: %s", consumerPID, err)
+		}
+	}
+	logger.Info("Contract finalized, continuing")
+	transferConsumerPID := uuid.New()
+	agreementID := uuid.MustParse(contract.GetAgreement().ID)
+
+	transferInit, err := statemachine.NewTransferRequest(
+		ctx,
+		s.store, s.provider, s.reconciler,
+		transferConsumerPID,
+		agreementID,
+		"HTTP_PULL",
+		providerURL,
+		selfURL,
+		statemachine.DataspaceConsumer,
+		statemachine.TransferRequestStates.TRANSFERINITIAL,
+		nil,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Couldn't create transfer request")
+	}
+	apply, err = transferInit.Send(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Couldn't generate inital initial request.")
+	}
+	logger.Debug("Beginning transfer request")
+	apply()
+
+	tReq, err := s.store.GetConsumerTransfer(ctx, transferConsumerPID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "could not get consumer transfer with PID %s: %s", transferConsumerPID, err)
+	}
+
+	logger.Info("Starting to monitor transfer request")
+	for tReq.GetState() != statemachine.TransferRequestStates.STARTED {
+		logger.Info("Transfer not started", "state", tReq.GetState().String())
+		time.Sleep(1 * time.Second)
+		tReq, err = s.store.GetConsumerTransfer(ctx, transferConsumerPID)
+		if err != nil {
+			return nil, status.Errorf(
+				codes.Internal, "could not get consumer contract with PID %s: %s", transferConsumerPID, err,
+			)
+		}
+	}
+
+	return &dspv1alpha1.GetProviderDatasetDownloadInformationResponse{
+		PublishInfo: tReq.GetPublishInfo(),
+		TransferId:  tReq.GetConsumerPID().String(),
+	}, nil
+}
+
+// Tells provider that we have finished our transfer.
+func (s *Server) SignalTransferComplete(
+	ctx context.Context, req *dspv1alpha1.SignalTransferCompleteRequest,
+) (*dspv1alpha1.SignalTransferCompleteResponse, error) {
+	id, err := uuid.Parse(req.GetTransferId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Transfer ID is not a valid UUID.")
+	}
+	trReq, err := s.store.GetConsumerTransfer(ctx, id)
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound, "no transfer found")
+	}
+	transferState := statemachine.GetTransferRequestNegotiation(s.store, trReq, s.provider, s.reconciler)
+	apply, err := transferState.Send(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "couldn't finish transfer: %s", err)
+	}
+	apply()
+	for trReq.GetState() != statemachine.TransferRequestStates.COMPLETED {
+		time.Sleep(1 * time.Second)
+		trReq, err = s.store.GetConsumerTransfer(ctx, id)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "could not get consumer contract with PID %s: %s", id, err)
+		}
+	}
+
+	return &dspv1alpha1.SignalTransferCompleteResponse{}, nil
+}
+
+// Tells provider to cancel file transfer.
+func (s *Server) SignalTransferCancelled(
+	_ context.Context, _ *dspv1alpha1.SignalTransferCancelledRequest,
+) (*dspv1alpha1.SignalTransferCancelledResponse, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+// Tells provider to suspend file transfer.
+func (s *Server) SignalTransferSuspend(
+	_ context.Context, _ *dspv1alpha1.SignalTransferSuspendRequest,
+) (*dspv1alpha1.SignalTransferSuspendResponse, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+// Tells provider to resume file transfer.
+func (s *Server) SignalTransferResume(
+	_ context.Context, _ *dspv1alpha1.SignalTransferResumeRequest,
+) (*dspv1alpha1.SignalTransferResumeResponse, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+func processCatalogue(cat []shared.Dataset) []*dspv1alpha1.Dataset {
+	rCat := make([]*dspv1alpha1.Dataset, len(cat))
+	for i, d := range cat {
+		rCat[i] = processDataset(d)
+	}
+	return rCat
+}
+
+func processDataset(dsp shared.Dataset) *dspv1alpha1.Dataset {
+	desc := make([]*dspv1alpha1.Multilingual, len(dsp.Description))
+	for i, v := range dsp.Description {
+		desc[i] = &dspv1alpha1.Multilingual{
+			Value:    v.Value,
+			Language: v.Language,
+		}
+	}
+	issued, err := time.Parse(dsp.Issued, time.RFC3339)
+	if err != nil {
+		issued = time.Unix(0, 0).UTC()
+	}
+	modified, err := time.Parse(dsp.Modified, time.RFC3339)
+	if err != nil {
+		modified = time.Unix(0, 0).UTC()
+	}
+	a := ""
+	if len(dsp.Distribution) > 0 {
+		a = dsp.Distribution[0].Format
+	}
+	return &dspv1alpha1.Dataset{
+		Id:            strings.TrimPrefix(dsp.ID, "urn:uuid:%s"),
+		Title:         dsp.Title,
+		AccessMethods: a,
+		Description:   desc,
+		Keywords:      dsp.Keyword,
+		Creator:       &dsp.Creator,
+		Issued:        timestamppb.New(issued),
+		Modified:      timestamppb.New(modified),
+		Metadata:      map[string]string{},
+	}
+}
+
+func encodeRequestDecode[B any, R any](
+	ctx context.Context, r shared.Requester, method string, u *url.URL, body B,
+) (R, error) {
+	var resp R
+	reqBody, err := shared.ValidateAndMarshal(ctx, body)
+	if err != nil {
+		return resp, status.Errorf(codes.Internal, "could not encode requst body: %s", err)
+	}
+	respBody, err := r.SendHTTPRequest(ctx, method, u, reqBody)
+	if err != nil {
+		return resp, status.Errorf(codes.Unavailable, "could not request %s: %s", u.String(), err)
+	}
+	resp, err = shared.UnmarshalAndValidate(ctx, respBody, resp)
+	if err != nil {
+		return resp, status.Errorf(codes.FailedPrecondition, "could not decode response: %s", err)
+	}
+	return resp, nil
+}

--- a/dsp/shared/http.go
+++ b/dsp/shared/http.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package statemachine
+package shared
 
 import (
 	"bytes"
@@ -48,7 +48,11 @@ func (hr *HTTPRequester) SendHTTPRequest(
 	}
 	logger := logging.Extract(ctx).With("method", method, "target_url", url)
 	logger.Debug("Doing HTTP request")
-	req, err := http.NewRequestWithContext(ctx, method, url.String(), bytes.NewReader(reqBody))
+	var payload io.Reader
+	if reqBody != nil {
+		payload = bytes.NewReader(reqBody)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url.String(), payload)
 	if err != nil {
 		logger.Error("Failed to create request", "err", err)
 		return nil, err
@@ -74,4 +78,12 @@ func (hr *HTTPRequester) SendHTTPRequest(
 	}
 
 	return respBody, nil
+}
+
+func MustParseURL(u string) *url.URL {
+	pu, err := url.Parse(u)
+	if err != nil {
+		panic(err.Error())
+	}
+	return pu
 }

--- a/dsp/statemachine/reconciler.go
+++ b/dsp/statemachine/reconciler.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/go-dataspace/run-dsp/dsp/shared"
 	"github.com/go-dataspace/run-dsp/logging"
 	"github.com/google/uuid"
 )
@@ -58,11 +59,11 @@ type ReconciliationEntry struct {
 type Reconciler struct {
 	ctx context.Context
 	c   chan ReconciliationEntry
-	r   Requester
+	r   shared.Requester
 	a   Archiver
 }
 
-func NewReconciler(ctx context.Context, r Requester, a Archiver) *Reconciler {
+func NewReconciler(ctx context.Context, r shared.Requester, a Archiver) *Reconciler {
 	return &Reconciler{
 		ctx: ctx,
 		c:   make(chan ReconciliationEntry),

--- a/dsp/statemachine/transfer_messages.go
+++ b/dsp/statemachine/transfer_messages.go
@@ -194,7 +194,7 @@ func publishInfoToDataAddress(pi *providerv1.PublishInfo) shared.DataAddress {
 			},
 		}
 	case providerv1.AuthenticationType_AUTHENTICATION_TYPE_UNSPECIFIED:
-		panic(fmt.Sprintf("unexpected providerv1.AuthenticationType: %#v", pi.AuthenticationType))
+		da.EndpointProperties = []shared.EndpointProperty{}
 	default:
 		panic(fmt.Sprintf("unexpected providerv1.AuthenticationType: %#v", pi.AuthenticationType))
 	}

--- a/dsp/statemachine/transfer_request_transitions.go
+++ b/dsp/statemachine/transfer_request_transitions.go
@@ -264,9 +264,10 @@ func dataAddressToPublishInfo(d shared.DataAddress) (*providerv1.PublishInfo, er
 	pi := &providerv1.PublishInfo{
 		Url: d.Endpoint,
 	}
+
 	authType, ok := p["authType"]
 	if !ok {
-		return nil, fmt.Errorf("no authtype defined")
+		return pi, nil
 	}
 	switch authType {
 	case "bearer":

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/samber/slog-http v1.3.1
 	github.com/stretchr/testify v1.9.0
 	google.golang.org/grpc v1.64.1
+	google.golang.org/protobuf v1.34.2
 )
 
 require (
@@ -30,6 +31,5 @@ require (
 	golang.org/x/sys v0.21.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
-	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gabriel-vasile/mimetype v1.4.4 h1:QjV6pZ7/XZ7ryI2KuyeEDE8wnh7fHP9YnQy+R0LnH8I=
 github.com/gabriel-vasile/mimetype v1.4.4/go.mod h1:JwLei5XPtWdGiMFB5Pjle1oEeoSeEuJfJE+TtfvdB/s=
-github.com/go-dataspace/run-dsrpc v0.0.0-20240627145957-5231d8809908 h1:4rd+x85I9ofdA7u6zcBCEUlMwKkAaLma+c+pt+QIYis=
-github.com/go-dataspace/run-dsrpc v0.0.0-20240627145957-5231d8809908/go.mod h1:LuGi7aKGllDAc13Re677LwF6WOqK0hHsl0Aq16ytcIY=
 github.com/go-dataspace/run-dsrpc v0.0.1-alpha1 h1:5AidaX66NMAjjVGjKRm/DMEw+xEySdn5dm8WUzWI73M=
 github.com/go-dataspace/run-dsrpc v0.0.1-alpha1/go.mod h1:GS4hV6keaQWCn9KTwMqNgzOdIgPnJ/+NSHSvgrsLbTE=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=

--- a/internal/authforwarder/grpcinjector.go
+++ b/internal/authforwarder/grpcinjector.go
@@ -57,7 +57,11 @@ func UnaryInterceptor(
 		return nil, errMissingMetadata
 	}
 	authContents := md["authorization"]
-	ctx = context.WithValue(ctx, contextKey, authContents)
+	ac := ""
+	if len(authContents) > 0 {
+		ac = authContents[0]
+	}
+	ctx = context.WithValue(ctx, contextKey, ac)
 	return handler(ctx, req)
 }
 
@@ -81,7 +85,11 @@ func StreamInterceptor(
 		return errMissingMetadata
 	}
 	authContents := md["authorization"]
-	ctx = context.WithValue(ctx, contextKey, authContents)
+	ac := ""
+	if len(authContents) > 0 {
+		ac = authContents[0]
+	}
+	ctx = context.WithValue(ctx, contextKey, ac)
 	return handler(srv, &serverStream{ss, ctx})
 }
 


### PR DESCRIPTION
To make non-dataspace client communication with the dataspace
possible, we're adding a GRPC control interface.