### PR TITLE
Upgrade gRPC provider bindings.

### DIFF
--- a/dsp/shared/catalog_types.go
+++ b/dsp/shared/catalog_types.go
@@ -69,14 +69,28 @@ type Resource struct {
 
 // Distribution is a DCAT distribution.
 type Distribution struct {
-	Type          string          `json:"@type" validate:"required,eq=dcat:Distribution"`
-	Format        string          `json:"dct:format,omitempty"`
-	Title         string          `json:"dct:title,omitempty"`
-	Description   []Multilanguage `json:"dct:description,omitempty"`
-	Issued        string          `json:"dct:issued,omitempty"`
-	Modified      string          `json:"dct:modified,omitempty"`
-	HasPolicy     []odrl.Offer    `json:"odrl:hasPolicy,omitempty"`
-	AccessService []DataService   `json:"dcat:accessService" validate:"required,gte=1"`
+	Type           string          `json:"@type,omitempty" validate:"required,eq=dcat:Distribution"`
+	Format         string          `json:"dct:format,omitempty"`
+	Title          string          `json:"dct:title,omitempty"`
+	Description    []Multilanguage `json:"dct:description,omitempty"`
+	Issued         string          `json:"dct:issued,omitempty"`
+	Modified       string          `json:"dct:modified,omitempty"`
+	HasPolicy      []odrl.Offer    `json:"odrl:hasPolicy,omitempty"`
+	AccessService  []DataService   `json:"dcat:accessService,omitempty" validate:"required,gte=1"`
+	License        string          `json:"dcterms:license,omitempty"`
+	AccessRights   string          `json:"dcterms:accessRights,omitempty"`
+	Rights         string          `json:"dcterms:rights,omitempty"`
+	ByteSize       int             `json:"dcat:byteSize,omitempty"`
+	MediaType      string          `json:"dcat:mediaType,omitempty"`
+	CompressFormat string          `json:"dcat:compressFormat,omitempty"`
+	PackageFormat  string          `json:"dcat:packageFormat,omitempty"`
+	Checksum       *Checksum       `json:"spdx:checksum,omitempty"`
+}
+
+// Checksum is a DCAT checksum.
+type Checksum struct {
+	Algorithm string `json:"spdx:algorithm,omitempty"`
+	Value     string `json:"spdx:checksumValue,omitempty"`
 }
 
 // DataService is a DCAT dataservice.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.5
 
 require (
 	github.com/alecthomas/kong v0.9.0
-	github.com/go-dataspace/run-dsrpc v0.0.2-alpha1
+	github.com/go-dataspace/run-dsrpc v0.0.3-alpha1
 	github.com/go-playground/validator/v10 v10.22.0
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/go-dataspace/run-dsrpc v0.0.1-alpha1 h1:5AidaX66NMAjjVGjKRm/DMEw+xEyS
 github.com/go-dataspace/run-dsrpc v0.0.1-alpha1/go.mod h1:GS4hV6keaQWCn9KTwMqNgzOdIgPnJ/+NSHSvgrsLbTE=
 github.com/go-dataspace/run-dsrpc v0.0.2-alpha1 h1:MMOqPIMZ0Qwor8EQAsLJVQsE46//8zZP0uxz6jh5LWY=
 github.com/go-dataspace/run-dsrpc v0.0.2-alpha1/go.mod h1:GS4hV6keaQWCn9KTwMqNgzOdIgPnJ/+NSHSvgrsLbTE=
+github.com/go-dataspace/run-dsrpc v0.0.3-alpha1 h1:YvzHkw7ew+A7NMxOfwD6jOQ5Ki49BvKmzDhohzyYNPQ=
+github.com/go-dataspace/run-dsrpc v0.0.3-alpha1/go.mod h1:GS4hV6keaQWCn9KTwMqNgzOdIgPnJ/+NSHSvgrsLbTE=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=

--- a/internal/server/command.go
+++ b/internal/server/command.go
@@ -196,7 +196,6 @@ func (c *Command) Run(p cli.Params) error {
 	reconciler.Run()
 
 	mux := http.NewServeMux()
-
 	baseMW := alice.New(
 		sloghttp.Recovery,
 		sloghttp.New(logger),
@@ -206,7 +205,6 @@ func (c *Command) Run(p cli.Params) error {
 		"/.well-known",
 		baseMW.Append(jsonHeaderMiddleware).Then(dsp.GetWellKnownRoutes()),
 	))
-
 	selfURL := cloneURL(c.ExternalURL)
 	selfURL.Path = path.Join(selfURL.Path, constants.APIPath)
 	mux.Handle(constants.APIPath+"/", http.StripPrefix(


### PR DESCRIPTION
This updates the gRPC provider bindings to 0.0.3-alpha1.

That version added more fields to the dataset message, and
we start to support them with this PR.