### PR TITLE
Add devcontainer workflow support.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22
+FROM docker.io/library/golang:1.22
 
 RUN apt-get update && \
     # Go tools:

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,10 +17,7 @@ RUN apt-get update && \
     # https://go.dev/security/vuln/
     go install golang.org/x/vuln/cmd/govulncheck@latest && \
     # Graphviz for visualizing go test pprof profiles.
-    apt-get -y install graphviz && \
-    # Docker cli
-    curl -fsSL https://get.docker.com -o get-docker.sh && \
-    sh get-docker.sh
+    apt-get -y install graphviz
 
 ADD . /workspace
 WORKDIR /workspace

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,29 @@
+FROM golang:1.22
+
+RUN apt-get update && \
+    # Go tools:
+    # - https://github.com/golang/tools
+    # - https://github.com/golang/vscode-go/blob/HEAD/docs/tools.md
+    go install -v golang.org/x/tools/gopls@latest && \
+    go install github.com/cweill/gotests/gotests@latest && \
+    go install github.com/fatih/gomodifytags@latest && \
+    go install github.com/josharian/impl@latest && \
+    go install github.com/haya14busa/goplay/cmd/goplay@latest && \
+    go install github.com/go-delve/delve/cmd/dlv@latest && \
+    go install honnef.co/go/tools/cmd/staticcheck@latest && \
+    go install golang.org/x/tools/cmd/godoc@latest && \
+    go install gotest.tools/gotestsum@latest && \
+    # Go vulnerability checker:
+    # https://go.dev/security/vuln/
+    go install golang.org/x/vuln/cmd/govulncheck@latest && \
+    # Graphviz for visualizing go test pprof profiles.
+    apt-get -y install graphviz && \
+    # Docker cli
+    curl -fsSL https://get.docker.com -o get-docker.sh && \
+    sh get-docker.sh
+
+ADD . /workspace
+WORKDIR /workspace
+
+CMD ["sleep", "infinity"]
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+    "name": "godev",
+    "workspaceFolder": "/workspace",
+    "dockerComposeFile": [
+        "docker-compose.yml"
+    ],
+    "service": "godev",
+    "postStartCommand": "go version",
+	"forwardPorts": [8080],
+	"customizations": {
+        "vscode": {
+            "extensions": [
+                "golang.go",
+                "ms-azuretools.vscode-docker"
+            ]
+        }
+    }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,9 +6,8 @@ services:
       context: ../
       dockerfile: ./.devcontainer/Dockerfile
     volumes:
-      - ${HOME}/.ssh:/root/.ssh:ro
-      - ../:/workspace:cached
-      - /var/run/docker.sock:/var/run/docker.sock
+      - ${HOME}/.ssh:/root/.ssh:ro,z
+      - ../:/workspace:cached,z
   reference-provider:
     image: ghcr.io/go-dataspace/reference-provider:main
     command: server

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.9'
+services:
+  godev:
+    container_name: godev
+    build:
+      context: ../
+      dockerfile: ./.devcontainer/Dockerfile
+    volumes:
+      - ${HOME}/.ssh:/root/.ssh:ro
+      - ../:/workspace:cached
+      - /var/run/docker.sock:/var/run/docker.sock
+  reference-provider:
+    image: ghcr.io/go-dataspace/reference-provider:main
+    command: server
+    environment:
+      - LOGLEVEL=debug
+      - PROVIDER_INSECURE=true
+      - EXTERNAL_URL=http://127.0.0.1:9091/
+    volumes:
+    - .:/var/lib/run-dsp/fsprovider
+    ports:
+      - '9091'

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Run DSP",
+            "name": "Run DSP local",
             "type": "go",
             "request": "launch",
             "mode": "auto",
@@ -15,6 +15,26 @@
                 "--debug",
                 "--provider-address",
                 "127.0.0.1:9090",
+                "--provider-insecure",
+                "--control-enabled",
+                "--control-insecure",
+                "--external-url=http://127.0.0.1:8080",
+            ]
+        },
+        {
+            "name": "Run DSP devcontainer",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/cmd/",
+            "buildFlags": [
+                "-buildvcs=false"
+            ],
+            "args": [
+                "server",
+                "--debug",
+                "--provider-address",
+                "reference-provider:9090",
                 "--provider-insecure",
                 "--control-enabled",
                 "--control-insecure",


### PR DESCRIPTION
Based this on: https://godev.com/questions/D1G1/how-to-use-a-dev-container-with-vs-code

Note: We should maybe look into other features to enable with the config?

Fixes https://github.com/go-dataspace/run-dsp/issues/56 and https://github.com/go-dataspace/run-dsp/issues/57.