### PR TITLE
Only unpublish a dataset on the provider.

### DIFF
--- a/dsp/statemachine/transfer_request_transitions.go
+++ b/dsp/statemachine/transfer_request_transitions.go
@@ -159,11 +159,13 @@ func (tr *TransferRequestNegotiationStarted) Recv(
 func (tr *TransferRequestNegotiationStarted) Send(ctx context.Context) (func(), error) {
 	switch tr.GetTransferDirection() {
 	case DirectionPull:
-		_, err := tr.GetProvider().UnpublishDataset(ctx, &providerv1.UnpublishDatasetRequest{
-			PublishId: tr.GetProviderPID().String(),
-		})
-		if err != nil {
-			return func() {}, err
+		if tr.GetRole() == DataspaceProvider {
+			_, err := tr.GetProvider().UnpublishDataset(ctx, &providerv1.UnpublishDatasetRequest{
+				PublishId: tr.GetProviderPID().String(),
+			})
+			if err != nil {
+				return func() {}, err
+			}
 		}
 	case DirectionPush:
 		// TODO: Signal provider to start uploading dataset here.


### PR DESCRIPTION
In the started state, we only want to unpublish pull direction datasets
on the provider.