### PR TITLE
Ainmosni/feature/docker-compose-debug

### DIFF
--- a/.github/workflows/build-and-push-debug-image.yaml
+++ b/.github/workflows/build-and-push-debug-image.yaml
@@ -59,7 +59,7 @@ jobs:
           flavor: |
             latest=false
             prefix=
-            suffix=debug
+            suffix=-DEBUG
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.

--- a/.github/workflows/build-and-push-debug-image.yaml
+++ b/.github/workflows/build-and-push-debug-image.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 #
-name: Create and publish a Docker image
+name: Create and publish a debug Docker image
 
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:

--- a/.github/workflows/build-and-push-debug-image.yaml
+++ b/.github/workflows/build-and-push-debug-image.yaml
@@ -18,7 +18,10 @@ name: Create and publish a Docker image
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
   push:
+    branches:
+      - main
     tags:
+      - v*
       - snapshot-*
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
@@ -42,7 +45,7 @@ jobs:
         uses: actions/checkout@v4
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -50,17 +53,30 @@ jobs:
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+            prefix=
+            suffix=debug
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v6
         with:
           context: .
+          file: Dockerfile.debug
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)."
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -22,6 +22,7 @@ on:
       - main
     tags:
       - v*
+      - snapshot-*
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:
@@ -44,7 +45,7 @@ jobs:
         uses: actions/checkout@v4
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -52,7 +53,7 @@ jobs:
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
@@ -60,7 +61,7 @@ jobs:
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,5 +31,35 @@
                 "server",
             ]
         }
+        {
+            "name": "Dev Dataspace: Attach to consumer",
+            "type": "go",
+            "debugAdapter": "dlv-dap",
+            "request": "attach",
+            "mode": "remote",
+            "port": 14000,
+            "host": "127.0.0.1",
+            "substitutePath": [
+                {
+                    "from": "${workspaceFolder}",
+                    "to": "/app"
+                },
+            ]
+        },
+        {
+            "name": "Dev Dataspace: Attach to provider",
+            "type": "go",
+            "debugAdapter": "dlv-dap",
+            "request": "attach",
+            "mode": "remote",
+            "port": 24000,
+            "host": "127.0.0.1",
+            "substitutePath": [
+                {
+                    "from": "${workspaceFolder}",
+                    "to": "/app"
+                },
+            ]
+        }
     ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/library/golang:1.22.5 AS builder
+FROM docker.io/library/golang:1.22.9 AS builder
 WORKDIR /app
 COPY . ./
 RUN make build

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -12,27 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-BINARY_NAME := run-dsp
-
-build:
-	-mkdir _build
-	go mod download
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -ldflags="-extldflags=-static" -o _build/$(BINARY_NAME) ./cmd/
-
-debug:
-	-mkdir _build
-	go mod download
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -gcflags=all="-N -l" -ldflags="-extldflags=-static" -o _build/$(BINARY_NAME).debug ./cmd/
-
-
-test:
-	go test -v ./...
-
-lint:
-	golangci-lint run
-
-vulncheck:
-	govulncheck ./...
-
-generate:
-	go generate ./...
+# This creates an image that
+FROM docker.io/library/golang:1.22.9 AS builder
+WORKDIR /app
+COPY . ./
+RUN make debug
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+ENTRYPOINT [ "/go/bin/dlv", "exec", "--listen=:4000", "--headless", "--log", "--accept-multiclient", "--continue",  "./_build/run-dsp.debug" ]

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This creates an image that
+# This creates an image that runs a run-dsp debug binary in dlv.
+###########################################
+# DO NOT USE ANYWHERE NEAR SENSITIVE DATA #
+###########################################
 FROM docker.io/library/golang:1.22.9 AS builder
 WORKDIR /app
 COPY . ./

--- a/README.md
+++ b/README.md
@@ -40,7 +40,14 @@ side from a single installation if properly configured.
 
 ## Getting started
 
+### Demo
+
+You can find how to setup a simple demo dataspace in the  [dev-dataspace](./docs/development/dev-dataspace/README.md)
+directory.
+
 ### Development
+
+#### Local
 
 To start developing on RUN-DSP itself, you can set up a basic setup like this:
 
@@ -57,6 +64,11 @@ $ go run ./cmd/ -c ./conf/localdev.toml sever
 ```
 
 You can now start hacking and testing RUN-DSP.
+
+#### In the demo dataspace
+
+The [dev-dataspace](./docs/development/dev-dataspace/README.md) demo setup can also be used to test
+and debug RUN-DSP.
 
 ### Integration
 

--- a/docs/development/dev-dataspace/README.md
+++ b/docs/development/dev-dataspace/README.md
@@ -1,0 +1,72 @@
+# Simple development dataspace
+
+## Introduction
+
+A dataspace is a pretty complicated setup, it consists of multiple participants that request operations
+from each other via the [dataspace protocol](https://docs.internationaldataspaces.org/ids-knowledgebase/dataspace-protocol).
+
+In order to test RUN-DSP, or to debug interactions between two participants, we've supplied this
+development dataspace. It sets up two RUN-DSP instances and a provider. One of them is marked as
+the `consumer` while the other is marked as the `provider`. What these roles are is described in
+the above protocol specification.
+
+## Prerequisites
+
+This setup expects you have `docker-compose` installed. This setup is also tested in rootless
+`podman`, as long as the environment variable `DOCKER_HOST` is set to the appropriate socket.
+
+Client examples assume you have RUN-DSP installed and in your PATH, you can get a precompiled binary
+[here](https://github.com/go-dataspace/run-dsp/releases/latest).
+
+Alternatively, if you have go installed, you can also replace every instance of the `run-dsp` command
+with `go run ./cmd/`, assuming you are in the root of this repository.
+
+## Using the dev dataspace
+
+To build a simple dataspace using the current state of your local git repository, just run the
+following in the same directory as this file:
+
+```bash
+$ docker-compose up
+```
+
+This will start the following containers:
+
+- `run-dsp-client`: The RUN-DSP instance that will act as a client.
+- `run-dsp-provider`: The RUN-DSP instance that will act as a provider.
+- `reference-provider`: The simple [reference provider](https://github.com/go-dataspace/reference-provider) that RUN-DSP will request dataset operations from.
+
+Note, inside the docker-compose network, their names are also their hostnames.
+
+
+And to see if everything works correctly, try to request the provider's catalog:
+
+```bash
+$ run-dsp -f ./dev-dataspace.conf client getcatalog http://run-dsp-provider:8080
+```
+
+This should display a catalog of two separate files, for more information on how to use the client,
+you can view its documentation [here](../../usage/client.md).
+
+## Development
+
+To use this setup for development purposes, it will be good to know that the RUN-DSP instances are
+all built from the local source base, so deleting and recreating the setup will incorporate any changes
+you have made.
+
+For debugging, both containers run their instances inside of a headless [delve](https://github.com/go-delve/delve)
+debug session that you can connect to.
+
+For the consumer instance:
+```bash
+$ dlv connect :14000
+```
+
+And for the provider instance:
+```bash
+$ dlv connect :24000
+```
+
+For convenience, we've also added two entries in the project's [launch.json](../../../.vscode/launch.json)
+to allow [Visual Studio Code](https://code.visualstudio.com/) users to use the `dlv` integration
+out of the box. Do note that these won't start up the development dataspace, this will have to be done by hand.

--- a/docs/development/dev-dataspace/README.md
+++ b/docs/development/dev-dataspace/README.md
@@ -42,7 +42,7 @@ Note, inside the docker-compose network, their names are also their hostnames.
 And to see if everything works correctly, try to request the provider's catalog:
 
 ```bash
-$ run-dsp -f ./dev-dataspace.conf client getcatalog http://run-dsp-provider:8080
+$ run-dsp -f ./run-dsp.toml client getcatalog http://run-dsp-provider:8080
 ```
 
 This should display a catalog of two separate files, for more information on how to use the client,

--- a/docs/development/dev-dataspace/docker-compose.yml
+++ b/docs/development/dev-dataspace/docker-compose.yml
@@ -16,11 +16,13 @@
 # insecure = true
 # authMD = "User1"
 #
-version: '3.9'
+name: run-dsp development dataspace
+
 services:
   run-dsp-client:
     build:
       context: ../../../
+      dockerfile: Dockerfile.debug
     command: server
     environment:
       - LOGLEVEL=debug
@@ -31,17 +33,22 @@ services:
       - SERVER.CONTROL.INSECURE=true
     ports:
       - '18081:8081'
+      - '14000:4000'
     depends_on:
       - reference-provider
   run-dsp-provider:
     build:
       context: ../../../
+      dockerfile: Dockerfile.debug
     command: server
     environment:
       - LOGLEVEL=debug
       - SERVER.PROVIDER.ADDRESS=reference-provider:9090
       - SERVER.PROVIDER.INSECURE=true
       - SERVER.DSP.EXTERNALURL=http://run-dsp-provider:8080/
+    ports:
+      - '28081:8081'
+      - '24000:4000'
     depends_on:
       - reference-provider
   reference-provider:
@@ -52,4 +59,5 @@ services:
       - PROVIDER_INSECURE=true
       - EXTERNAL_URL=http://127.0.0.1:19091/
     ports:
+      - '19090:9090'
       - '19091:9091'

--- a/docs/development/dev-dataspace/docker-compose.yml
+++ b/docs/development/dev-dataspace/docker-compose.yml
@@ -41,6 +41,11 @@ services:
       context: ../../../
       dockerfile: Dockerfile.debug
     command: server
+    # When you want to emulate a slow provider, uncomment this.
+    # deploy:
+    #   resources:
+    #     limits:
+    #       cpus: '0.01'
     environment:
       - LOGLEVEL=debug
       - SERVER.PROVIDER.ADDRESS=reference-provider:9090

--- a/docs/development/dev-dataspace/run-dsp.toml
+++ b/docs/development/dev-dataspace/run-dsp.toml
@@ -1,0 +1,8 @@
+### GLOBAL OPTIONS ###
+debug = true       # Sets the output to a human readable format and sets the log level to debug. ($DEBUG)
+logLevel = "debug" # Sets the log level. Valid values: debug/info/warn/error ($LOGLEVEL)
+
+[client]
+address = "127.0.0.1:18081"
+insecure = true
+authMD = "User1"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-dataspace/run-dsp
 
-go 1.22.5
+go 1.22.9
 
 require (
 	github.com/alecthomas/chroma/v2 v2.14.0


### PR DESCRIPTION
To make it easier to debug RUN-DSP under more realistic circumstances, we need to be able to attach a debugger to remote services.

This PR contains the following changes:

- Add a Dockerfile.debug that runs a run-dsp debug binary in a headless debugger.
- Modifies the dev-dataspace docker-compose.yaml to expose the remote debugging ports.
- Adds a debug target to the Makefile
- Restructures the github actions so that the snapshot images get built from the same config as the normal images.
- Add a github action to create a debug image next to the normal image.
- Add launch.json targets that work with the dev dataspace docker-compose setup.