### PR TITLE
Add reconciliation loop

### DIFF
--- a/cmd/root/command.go
+++ b/cmd/root/command.go
@@ -86,6 +86,7 @@ func initConfig() {
 		viper.SetConfigFile(cfgFile)
 	} else {
 		viper.AddConfigPath("/etc/run-dsp")
+		viper.AddConfigPath("$HOME/.config/run-dsp")
 		viper.SetConfigType("toml")
 		viper.SetConfigName("run-dsp.toml")
 	}

--- a/docs/development/dev-dataspace/docker-compose.yml
+++ b/docs/development/dev-dataspace/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       dockerfile: Dockerfile.debug
     command: server
     environment:
+      - DEBUG=true
       - LOGLEVEL=debug
       - SERVER.PROVIDER.ADDRESS=reference-provider:9090
       - SERVER.PROVIDER.INSECURE=true
@@ -47,6 +48,7 @@ services:
     #     limits:
     #       cpus: '0.01'
     environment:
+      - DEBUG=true
       - LOGLEVEL=debug
       - SERVER.PROVIDER.ADDRESS=reference-provider:9090
       - SERVER.PROVIDER.INSECURE=true

--- a/dsp/control/control.go
+++ b/dsp/control/control.go
@@ -209,13 +209,18 @@ func (s *Server) GetProviderDatasetDownloadInformation(
 	}
 
 	logger.Info("Starting to monitor contract")
+	checks := 0
 	for contract.GetState() != statemachine.ContractStates.FINALIZED {
-		logger.Info("Contract not finalized", "state", contract.GetState().String())
+		// Only log the status every 10 checks.
+		if checks%10 == 0 {
+			logger.Info("Contract not finalized", "state", contract.GetState().String())
+		}
 		time.Sleep(1 * time.Second)
 		contract, err = s.store.GetConsumerContract(ctx, consumerPID)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "could not get consumer contract with PID %s: %s", consumerPID, err)
 		}
+		checks++
 	}
 	logger.Info("Contract finalized, continuing")
 	transferConsumerPID := uuid.New()

--- a/dsp/statemachine/contract_statemachine_test.go
+++ b/dsp/statemachine/contract_statemachine_test.go
@@ -63,7 +63,7 @@ func decode[T any](d []byte) (T, error) {
 }
 
 const (
-	reconcileWait = 10 * time.Millisecond
+	reconcileWait = 1 * time.Second
 )
 
 var (

--- a/dsp/statemachine/reconciler.go
+++ b/dsp/statemachine/reconciler.go
@@ -127,7 +127,7 @@ func (r *Reconciler) Add(entry ReconciliationEntry) {
 }
 
 func (r *Reconciler) manager() {
-	// We use a ticker to trigger iterations, this is to not hammer the queue in a tightloop.
+	// We use a ticker to trigger iterations, this is to not hammer the queue in a tight loop.
 	ticker := time.NewTicker(reconciliationMillis * time.Millisecond)
 	logger := logging.Extract(r.ctx)
 	for {

--- a/dsp/statemachine/reconciler.go
+++ b/dsp/statemachine/reconciler.go
@@ -220,7 +220,7 @@ func (r *Reconciler) terminate(ctx context.Context, entry ReconciliationEntry) {
 	logger := logging.Extract(ctx)
 	logger.Error("Terminating entry")
 
-	// For now, try 10 times to update the state to terminated, if it doesn't succeed panic.
+	// For now, try 10 times to update the state to terminated, if it doesn't succeed, panic.
 	// We will handle this cleaner the future, but this is to make any bugs obvious.
 	var err error
 	for range 10 {

--- a/dsp/statemachine/reconciler.go
+++ b/dsp/statemachine/reconciler.go
@@ -221,7 +221,7 @@ func (r *Reconciler) terminate(ctx context.Context, entry ReconciliationEntry) {
 	logger.Error("Terminating entry")
 
 	// For now, try 10 times to update the state to terminated, if it doesn't succeed, panic.
-	// We will handle this cleaner the future, but this is to make any bugs obvious.
+	// We will handle this cleaner in the future, but this is to make any bugs obvious.
 	var err error
 	for range 10 {
 		err = r.updateState(ctx, entry, "dspace:TERMINATED")

--- a/dsp/statemachine/reconciler.go
+++ b/dsp/statemachine/reconciler.go
@@ -75,7 +75,7 @@ type ReconciliationEntry struct {
 }
 
 // Reconciler is a tries to send out all the http requests, and retries them if something fails.
-// A request has an exponential backoff that's defined in calculateNextAttempt.
+// A request has an exponential backoff that is defined in calculateNextAttempt.
 // But simply said it takes the previous interval, adds 50% to that, and then randomises it a bit.
 //
 // Right now, barely anything signals an immediate stop, but the option for that is already

--- a/dsp/statemachine/reconciler.go
+++ b/dsp/statemachine/reconciler.go
@@ -74,7 +74,7 @@ type ReconciliationEntry struct {
 	Context     context.Context
 }
 
-// Reconciler is a tries to send out all the http requests, and retries them if something fails.
+// Reconciler tries to send out all the http requests, and retries them if something fails.
 // A request has an exponential backoff that is defined in calculateNextAttempt.
 // But simply said it takes the previous interval, adds 50% to that, and then randomises it a bit.
 //

--- a/dsp/statemachine/reconciler.go
+++ b/dsp/statemachine/reconciler.go
@@ -78,7 +78,7 @@ type ReconciliationEntry struct {
 // A request has an exponential backoff that is defined in calculateNextAttempt.
 // But simply said it takes the previous interval, adds 50% to that, and then randomises it a bit.
 //
-// Right now, barely anything signals an immediate stop, but the option for that is already
+// Right now, almost nothing signals an immediate stop, but the option for that is already
 // available.
 type Reconciler struct {
 	ctx context.Context

--- a/dsp/statemachine/reconciler.go
+++ b/dsp/statemachine/reconciler.go
@@ -18,10 +18,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
+	"math/rand/v2"
 	"net/url"
+	"sync"
 	"time"
 
+	"github.com/gammazero/deque"
 	"github.com/go-dataspace/run-dsp/dsp/shared"
 	"github.com/go-dataspace/run-dsp/logging"
 	"github.com/google/uuid"
@@ -40,53 +42,130 @@ const (
 	ReconciliationTransferRequest
 )
 
+const (
+	initialQueueSize     = 100
+	reconciliationMillis = 10
+	workers              = 1
+
+	// Backoff settings.
+	maxAttempts         = 50
+	maxDuration         = 1 * time.Minute
+	initialRetry        = 500 * time.Millisecond
+	multiplier          = 1.5
+	randomizationFactor = 0.5
+)
+
+type reconciliationOperation struct {
+	Submitted       time.Time
+	NextAttempt     time.Time
+	Attempts        int
+	Entry           ReconciliationEntry
+	CurrentInterval time.Duration
+}
+
 type ReconciliationEntry struct {
 	EntityID    uuid.UUID
 	Type        ReconciliationType
 	Role        DataspaceRole
 	TargetState string
-	NextAttempt time.Time
 	Method      string
 	URL         *url.URL
 	Body        []byte
-	Attempts    int
 	Context     context.Context
 }
 
-// Reconciler is a naive reconciler loop. This should eventually be in its own package.
-// TODO: This needs to be much more robust, right now it doesn't really do anything with the
-// next attempt time or te amount of attempts. It also doesn't support any persistence.
+// Reconciler is a tries to send out all the http requests, and retries them if something fails.
+// A request has an exponential backoff that's defined in calculateNextAttempt.
+// But simply said it takes the previous interval, adds 50% to that, and then randomises it a bit.
+//
+// Right now, barely anything signals an immediate stop, but the option for that is already
+// available.
 type Reconciler struct {
 	ctx context.Context
-	c   chan ReconciliationEntry
+	c   chan reconciliationOperation
 	r   shared.Requester
 	a   Archiver
+	q   *deque.Deque[reconciliationOperation]
+
+	// Waitgroup to keep track of management/worker processes, not called from the command yet,
+	// as that is pending on the http server respecting contexts.
+	WaitGroup sync.WaitGroup
+	sync.Mutex
 }
 
 func NewReconciler(ctx context.Context, r shared.Requester, a Archiver) *Reconciler {
+	q := &deque.Deque[reconciliationOperation]{}
+	q.Grow(initialQueueSize)
+
 	return &Reconciler{
 		ctx: ctx,
-		c:   make(chan ReconciliationEntry),
+		c:   make(chan reconciliationOperation),
 		r:   r,
 		a:   a,
+		q:   q,
 	}
 }
 
 func (r *Reconciler) Run() {
-	go r.run()
+	r.WaitGroup.Add(1 + workers)
+	go r.manager()
+	for range workers {
+		go r.worker()
+	}
 }
 
 func (r *Reconciler) Add(entry ReconciliationEntry) {
-	r.c <- entry
+	r.Lock()
+	defer r.Unlock()
+	r.q.PushBack(reconciliationOperation{
+		Submitted:       time.Now(),
+		NextAttempt:     time.Now(),
+		Attempts:        0,
+		Entry:           entry,
+		CurrentInterval: initialRetry,
+	})
 }
 
-func (r *Reconciler) run() {
+func (r *Reconciler) manager() {
+	// We use a ticker to trigger iterations, this is to not hammer the queue in a tightloop.
+	ticker := time.NewTicker(reconciliationMillis * time.Millisecond)
+	logger := logging.Extract(r.ctx)
+	for {
+		select {
+		case <-ticker.C:
+			if r.q.Len() == 0 {
+				continue
+			}
+
+			r.Lock()
+			op := r.q.PopFront()
+			r.Unlock()
+			if time.Now().After(op.NextAttempt) {
+				logger.Info("Reconciling...", "contract_id", op.Entry.EntityID)
+				op.Attempts++
+				r.c <- op
+				continue
+			}
+
+			r.Lock()
+			r.q.PushBack(op)
+			r.Unlock()
+		case <-r.ctx.Done():
+			ticker.Stop()
+			r.WaitGroup.Done()
+			return
+		}
+	}
+}
+
+func (r *Reconciler) worker() {
 	// rLogger is the non-entry specific logger for the reconciler
 	rLogger := logging.Extract(r.ctx)
 	rLogger.Info("Starting reconciliation loop")
 	for {
 		select {
-		case entry := <-r.c:
+		case op := <-r.c:
+			entry := op.Entry
 			ctx := context.WithoutCancel(entry.Context)
 			ctx, logger := logging.InjectLabels(ctx,
 				"entityType", entry.Type,
@@ -96,35 +175,92 @@ func (r *Reconciler) run() {
 				"url", entry.URL.String(),
 			)
 			logger.Info("Attempting to reconcile entry")
-			err := r.updateState(ctx, entry.EntityID, entry.Role, entry.Type, entry.TargetState)
+
+			// As the dataspace standard doesn't care if we parse this, we won't.
+			_, err := r.r.SendHTTPRequest(ctx, entry.Method, entry.URL, entry.Body)
 			if err != nil {
-				logger.Error("Could not update state", "err", err)
+				r.handleError(ctx, op, fmt.Errorf("Could not send HTTP request: %w", err))
 				continue
 			}
-			// As the dataspace standard doesn't care if we parse this, we won't.
-			// TODO: care more about this. Implement requeuing logic.
-			_, err = r.r.SendHTTPRequest(ctx, entry.Method, entry.URL, entry.Body)
+
+			err = r.updateState(ctx, entry, entry.TargetState)
 			if err != nil {
-				err := r.updateState(ctx, entry.EntityID, entry.Role, entry.Type, "dspace:TERMINATED")
-				logger.Error("Could not send HTTP request", "err", err)
+				r.handleError(ctx, op, fmt.Errorf("Could not update state: %w", err))
 				continue
 			}
 		case <-r.ctx.Done():
 			rLogger.Info("Context done called, exiting.")
+			r.WaitGroup.Done()
 			return
 		}
 	}
 }
 
-func (c *Reconciler) updateState(
-	ctx context.Context, id uuid.UUID, role DataspaceRole, reconType ReconciliationType, state string,
+func (r *Reconciler) handleError(ctx context.Context, op reconciliationOperation, err error) {
+	logger := logging.Extract(ctx).With(
+		"err", err, "submitted", op.Submitted, "attempts", op.Attempts, "orig_next_attempt", op.NextAttempt)
+	// If the error is fatal, just immediately terminate the operation.
+	if errors.Is(err, ErrFatal) || op.Attempts >= maxAttempts {
+		r.terminate(ctx, op.Entry)
+		return
+	}
+	op.NextAttempt, op.CurrentInterval = calculateNextAttempt(op.CurrentInterval, op.Attempts)
+	logger = logger.With("next_attempt", op.NextAttempt)
+	if op.NextAttempt.Sub(op.Submitted) > maxDuration {
+		r.terminate(ctx, op.Entry)
+		return
+	}
+	logger.Error("Requeuing operation")
+	r.Lock()
+	r.q.PushBack(op)
+	r.Unlock()
+}
+
+func (r *Reconciler) terminate(ctx context.Context, entry ReconciliationEntry) {
+	logger := logging.Extract(ctx)
+	logger.Error("Terminating entry")
+
+	// For now, try 10 times to update the state to terminated, if it doesn't succeed panic.
+	// We will handle this cleaner the future, but this is to make any bugs obvious.
+	var err error
+	for range 10 {
+		err = r.updateState(ctx, entry, "dspace:TERMINATED")
+		if err == nil {
+			logger.Debug("Entry terminated")
+			return
+		}
+		logger.Debug("Could not update state", "err", err)
+	}
+	panic(fmt.Sprintf("Could not set state to terminate, %s", err))
+}
+
+func calculateNextAttempt(currentInterval time.Duration, attempts int) (time.Time, time.Duration) {
+	// Base interval is currentInterval * multiplier unless it's the first retry
+	ci := float64(currentInterval)
+	if attempts != 1 {
+		ci *= multiplier
+	}
+
+	// Do some randomisation based on the randomization factor
+	delta := randomizationFactor * ci
+	minInterval := ci - delta
+	maxInterval := ci + delta
+	//nolint:gosec // This is not a security use of rand.
+	randomValue := time.Duration(minInterval + (rand.Float64() * (maxInterval - minInterval + 1)))
+
+	nextRun := time.Now().Add(randomValue)
+	return nextRun, time.Duration(ci)
+}
+
+func (r *Reconciler) updateState(
+	ctx context.Context, entry ReconciliationEntry, state string,
 ) error {
 	logger := logging.Extract(ctx)
-	switch reconType {
+	switch entry.Type {
 	case ReconciliationContract:
-		return c.setContractState(ctx, state, logger, role, id)
+		return r.setContractState(ctx, state, entry.Role, entry.EntityID)
 	case ReconciliationTransferRequest:
-		return c.setTransferState(ctx, state, logger, role, id)
+		return r.setTransferState(ctx, state, entry.Role, entry.EntityID)
 	case ReconciliationUndefined:
 		logger.Error("Undefined type")
 		return fmt.Errorf("Undefined type")
@@ -136,12 +272,11 @@ func (c *Reconciler) updateState(
 
 //nolint:dupl
 func (c *Reconciler) setTransferState(
-	ctx context.Context, state string, logger *slog.Logger, role DataspaceRole, id uuid.UUID,
+	ctx context.Context, state string, role DataspaceRole, id uuid.UUID,
 ) error {
 	ts, err := ParseTransferRequestState(state)
 	if err != nil {
-		logger.Error("Invalid state", "err", err)
-		return ErrFatal
+		return fmt.Errorf("%w: Invalid state: %w", ErrFatal, err)
 	}
 	var tr *TransferRequest
 	if role == DataspaceConsumer {
@@ -150,13 +285,11 @@ func (c *Reconciler) setTransferState(
 		tr, err = c.a.GetProviderTransfer(ctx, id)
 	}
 	if err != nil {
-		logger.Error("Can't find transfer request", "err", err)
-		return ErrTransient
+		return fmt.Errorf("Can't find transfer request: %w", err)
 	}
 	err = tr.SetState(ts)
 	if err != nil {
-		logger.Error("Can't change state", "err", err)
-		return ErrFatal
+		return fmt.Errorf("Can't change state: %w", err)
 	}
 	if role == DataspaceConsumer {
 		err = c.a.PutConsumerTransfer(ctx, tr)
@@ -164,20 +297,18 @@ func (c *Reconciler) setTransferState(
 		err = c.a.PutProviderTransfer(ctx, tr)
 	}
 	if err != nil {
-		logger.Error("Can't save transfer request")
-		return ErrTransient
+		return fmt.Errorf("Can't save transfer request: %w", err)
 	}
 	return nil
 }
 
 //nolint:dupl
 func (c *Reconciler) setContractState(
-	ctx context.Context, state string, logger *slog.Logger, role DataspaceRole, id uuid.UUID,
+	ctx context.Context, state string, role DataspaceRole, id uuid.UUID,
 ) error {
 	cs, err := ParseContractState(state)
 	if err != nil {
-		logger.Error("Invalid state", "err", err)
-		return ErrFatal
+		return fmt.Errorf("%w: Invalid state: %w", ErrFatal, err)
 	}
 	var con *Contract
 	if role == DataspaceConsumer {
@@ -186,13 +317,11 @@ func (c *Reconciler) setContractState(
 		con, err = c.a.GetProviderContract(ctx, id)
 	}
 	if err != nil {
-		logger.Error("Can't find contract", "err", err)
-		return ErrTransient
+		return fmt.Errorf("Can't find contract: %w", err)
 	}
 	err = con.SetState(cs)
 	if err != nil {
-		logger.Error("Can't change state", "err", err)
-		return ErrFatal
+		return fmt.Errorf("Can't change state: %w", err)
 	}
 	if role == DataspaceConsumer {
 		err = c.a.PutConsumerContract(ctx, con)
@@ -200,8 +329,7 @@ func (c *Reconciler) setContractState(
 		err = c.a.PutProviderContract(ctx, con)
 	}
 	if err != nil {
-		logger.Error("Can't save contract")
-		return ErrTransient
+		return fmt.Errorf("Can't save contract: %w", err)
 	}
 	return nil
 }

--- a/dsp/statemachine/reconciler.go
+++ b/dsp/statemachine/reconciler.go
@@ -231,7 +231,7 @@ func (r *Reconciler) terminate(ctx context.Context, entry ReconciliationEntry) {
 		}
 		logger.Debug("Could not update state", "err", err)
 	}
-	panic(fmt.Sprintf("Could not set state to terminate, %s", err))
+	panic(fmt.Sprintf("Could not set state to terminated, %s", err))
 }
 
 func calculateNextAttempt(currentInterval time.Duration, attempts int) (time.Time, time.Duration) {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.9
 require (
 	github.com/alecthomas/chroma/v2 v2.14.0
 	github.com/fatih/color v1.17.0
+	github.com/gammazero/deque v1.0.0
 	github.com/go-dataspace/run-dsrpc v0.0.3-alpha1
 	github.com/go-playground/validator/v10 v10.22.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/gabriel-vasile/mimetype v1.4.4 h1:QjV6pZ7/XZ7ryI2KuyeEDE8wnh7fHP9YnQy+R0LnH8I=
 github.com/gabriel-vasile/mimetype v1.4.4/go.mod h1:JwLei5XPtWdGiMFB5Pjle1oEeoSeEuJfJE+TtfvdB/s=
+github.com/gammazero/deque v1.0.0 h1:LTmimT8H7bXkkCy6gZX7zNLtkbz4NdS2z8LZuor3j34=
+github.com/gammazero/deque v1.0.0/go.mod h1:iflpYvtGfM3U8S8j+sZEKIak3SAKYpA5/SQewgfXDKo=
 github.com/go-dataspace/run-dsrpc v0.0.3-alpha1 h1:YvzHkw7ew+A7NMxOfwD6jOQ5Ki49BvKmzDhohzyYNPQ=
 github.com/go-dataspace/run-dsrpc v0.0.3-alpha1/go.mod h1:GS4hV6keaQWCn9KTwMqNgzOdIgPnJ/+NSHSvgrsLbTE=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=

--- a/internal/server/command.go
+++ b/internal/server/command.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/signal"
 	"path"
 	"sync"
 	"time"
@@ -212,6 +213,8 @@ type command struct {
 func (c *command) Run(ctx context.Context) error {
 	wg := &sync.WaitGroup{}
 	logger := logging.Extract(ctx)
+	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt, os.Kill)
+	defer cancel()
 
 	logger.Info("Starting server",
 		"listenAddr", c.ListenAddr,
@@ -268,6 +271,7 @@ func (c *command) Run(ctx context.Context) error {
 		Handler:           mux,
 		ReadHeaderTimeout: 2 * time.Second,
 	}
+	// TODO: Shut down webserver gracefully and use the reconciler waitgroup.
 	return srv.ListenAndServe()
 }
 
@@ -300,10 +304,12 @@ func (c *command) startControl(
 		grpc.Creds(tlsCredentials),
 		grpc.ChainUnaryInterceptor(
 			grpclog.UnaryServerInterceptor(interceptorLogger(logger), logOpts...),
+			logging.UnaryServerInterceptor(logger),
 			authforwarder.UnaryInterceptor,
 		),
 		grpc.ChainStreamInterceptor(
 			grpclog.StreamServerInterceptor(interceptorLogger(logger), logOpts...),
+			logging.StreamServerInterceptor(logger),
 			authforwarder.StreamInterceptor,
 		),
 	)

--- a/internal/server/command.go
+++ b/internal/server/command.go
@@ -257,7 +257,6 @@ func (c *command) Run(ctx context.Context) error {
 			authforwarder.HTTPMiddleware,
 		).Then(dsp.GetDSPRoutes(provider, store, reconciler, selfURL, pingResponse)),
 	))
-
 	if c.ControlEnabled {
 		ctlSVC := control.New(httpClient, store, reconciler, provider, selfURL)
 		err = c.startControl(ctx, wg, ctlSVC)
@@ -265,7 +264,6 @@ func (c *command) Run(ctx context.Context) error {
 			return err
 		}
 	}
-
 	srv := &http.Server{
 		Addr:              fmt.Sprintf("%s:%d", c.ListenAddr, c.Port),
 		Handler:           mux,

--- a/logging/grpcinjector.go
+++ b/logging/grpcinjector.go
@@ -1,0 +1,62 @@
+// Copyright 2024 go-dataspace
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"context"
+	"log/slog"
+
+	"google.golang.org/grpc"
+)
+
+// UnaryServerInterceptor injects the logger in the context.
+func UnaryServerInterceptor(logger *slog.Logger) grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
+	) (any, error) {
+		reqLogger := logger.With(
+			"type", "gRPC unary call",
+			"method", info.FullMethod,
+		)
+		ctx = Inject(ctx, reqLogger)
+		return handler(ctx, req)
+	}
+}
+
+type serverStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *serverStream) Context() context.Context {
+	return s.ctx
+}
+
+func StreamServerInterceptor(logger *slog.Logger) grpc.StreamServerInterceptor {
+	return func(
+		srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler,
+	) error {
+		ctx := ss.Context()
+		reqLogger := logger.With(
+			"type", "gRPC streaming call",
+			"method", info.FullMethod,
+			"client_stream", info.IsClientStream,
+			"server_stream", info.IsServerStream,
+		)
+		ctx = Inject(ctx, reqLogger)
+		return handler(srv, &serverStream{ss, ctx})
+	}
+}


### PR DESCRIPTION
This replaces the reconciliation loop shim with an actual loop.

When an entry gets added:

1. It gets added to a deque, scheduled for right away.
2. A manager checks the deque every 0.01 second.
3. For every entry that's in the deque it will check if it's schedules
4. It will run the entry as normal.
5. If something went wrong, we will check if it's been trying too long.
6. If not, we will schedule it in the future, increasing the interval
	exponentially.
7. If it tried for too many times or has been trying too long, the entry
	will be terminated.

Outside of that, some odds and ends have changed:

- Added an optional config file path.
- Set the dev-dataspace RUN-DSP instances to full debug mode.
- Made OS interrupts cleanly call the context cancel.
- Made the control contract monitor log less aggressively.
- Added a gRPC injector that injects the logger in the context.