### PR TITLE
Set in-memory db as default

### DIFF
--- a/internal/server/command.go
+++ b/internal/server/command.go
@@ -145,7 +145,7 @@ func init() {
 		persistenceBadgerMemory,
 		"badger-in-memory",
 		"Put badger database in memory, will not survive restarts",
-		false,
+		true,
 	)
 	cfg.AddPersistentFlag(
 		Command, persistenceBadgerDBPath, "badger-dbpath", "Path to store the badger database", "",


### PR DESCRIPTION
This enables the in-memory badger database by default so that upgrading is easier.