### PR TITLE
Allow auto accept on contract negotiations.

### DIFF
--- a/dsp/contract/negotiation.go
+++ b/dsp/contract/negotiation.go
@@ -70,6 +70,7 @@ type Negotiation struct {
 	callback    *url.URL
 	self        *url.URL
 	role        constants.DataspaceRole
+	autoAccept  bool
 
 	initial  bool
 	ro       bool
@@ -85,6 +86,7 @@ type storableNegotiation struct {
 	Callback    *url.URL
 	Self        *url.URL
 	Role        constants.DataspaceRole
+	AutoAccept  bool
 }
 
 func New(
@@ -93,6 +95,7 @@ func New(
 	offer odrl.Offer,
 	callback, self *url.URL,
 	role constants.DataspaceRole,
+	autoAccept bool,
 ) *Negotiation {
 	return &Negotiation{
 		providerPID: providerPID,
@@ -102,6 +105,7 @@ func New(
 		callback:    callback,
 		self:        self,
 		role:        role,
+		autoAccept:  autoAccept,
 		modified:    true,
 	}
 }
@@ -122,6 +126,7 @@ func FromBytes(b []byte) (*Negotiation, error) {
 		callback:    sn.Callback,
 		self:        sn.Self,
 		role:        sn.Role,
+		autoAccept:  sn.AutoAccept,
 	}, nil
 }
 
@@ -203,6 +208,11 @@ func (cn *Negotiation) SetCallback(u string) error {
 	return nil
 }
 
+// AutoAccept is a property that decides if we're going to accept all operations to do with
+// this contract negotiation.
+func (cn *Negotiation) AutoAccept() bool { return cn.autoAccept }
+func (cn *Negotiation) SetAutoAccept()   { cn.autoAccept = true }
+
 // Properties that decisions are based on.
 func (cn *Negotiation) ReadOnly() bool { return cn.ro }
 func (cn *Negotiation) Initial() bool  { return cn.initial }
@@ -232,6 +242,7 @@ func (cn *Negotiation) ToBytes() ([]byte, error) {
 		Callback:    cn.callback,
 		Self:        cn.self,
 		Role:        cn.role,
+		AutoAccept:  cn.autoAccept,
 	}
 	var buf bytes.Buffer
 	enc := gob.NewEncoder(&buf)

--- a/dsp/contract_handlers_test.go
+++ b/dsp/contract_handlers_test.go
@@ -23,6 +23,8 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"path"
 	"testing"
 	"time"
 
@@ -99,7 +101,7 @@ type environment struct {
 	reconciler      *mockReconciler
 }
 
-func setupEnvironment(t *testing.T) (
+func setupEnvironment(t *testing.T, autoAccept bool) (
 	context.Context,
 	context.CancelFunc,
 	*environment,
@@ -108,7 +110,11 @@ func setupEnvironment(t *testing.T) (
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
 	slog.SetDefault(logger)
 	prov := mockprovider.NewMockProviderServiceClient(t)
-	cService := mockprovider.NewMockContractServiceClient(t)
+	var cService *mockprovider.MockContractServiceClient
+	if !autoAccept {
+		// Only used in the initial requests as we don't set the negotiation there.
+		cService = mockprovider.NewMockContractServiceClient(t)
+	}
 	store, err := badger.New(ctx, true, "")
 	reconciler := &mockReconciler{}
 	assert.Nil(t, err)
@@ -162,6 +168,7 @@ func createNegotiation(
 	store persistence.StorageProvider,
 	state contract.State,
 	role constants.DataspaceRole,
+	autoAccept bool,
 ) {
 	t.Helper()
 	providerPID := staticProviderPID
@@ -174,6 +181,7 @@ func createNegotiation(
 		callBack,
 		selfURL,
 		role,
+		autoAccept,
 	)
 	err := store.PutContract(ctx, neg)
 	assert.Nil(t, err)
@@ -181,9 +189,9 @@ func createNegotiation(
 
 func TestNegotiationStatus(t *testing.T) {
 	t.Parallel()
-	ctx, cancel, env := setupEnvironment(t)
+	ctx, cancel, env := setupEnvironment(t, false)
 	defer cancel()
-	createNegotiation(ctx, t, env.store, contract.States.OFFERED, constants.DataspaceProvider)
+	createNegotiation(ctx, t, env.store, contract.States.OFFERED, constants.DataspaceProvider, false)
 	u := env.server.URL + fmt.Sprintf("/negotiations/%s", staticProviderPID.String())
 	status := fetchAndDecode[shared.ContractNegotiation](ctx, t, http.MethodGet, u, nil)
 	assert.Equal(t, "dspace:ContractNegotiation", status.Type)
@@ -192,352 +200,546 @@ func TestNegotiationStatus(t *testing.T) {
 	assert.Equal(t, contract.States.OFFERED.String(), status.State)
 }
 
+func mkRequestUrl(u *url.URL, parts ...string) string {
+	cu := shared.MustParseURL(u.String())
+	parts = append([]string{cu.Path}, parts...)
+	cu.Path = path.Join(parts...)
+	return cu.String()
+}
+
+//nolint:funlen
 func TestNegotiationProviderInitialRequest(t *testing.T) {
-	ctx, cancel, env := setupEnvironment(t)
-	defer cancel()
+	t.Parallel()
+	for _, autoAccept := range []bool{true, false} {
+		ctx, cancel, env := setupEnvironment(t, autoAccept)
+		defer cancel()
 
-	env.provider.On("GetDataset", mock.Anything, &provider.GetDatasetRequest{
-		DatasetId: targetID.String(),
-	}).Return(&provider.GetDatasetResponse{
-		Dataset: &provider.Dataset{},
-	}, nil)
+		env.provider.On("GetDataset", mock.Anything, &provider.GetDatasetRequest{
+			DatasetId: targetID.String(),
+		}).Return(&provider.GetDatasetResponse{
+			Dataset: &provider.Dataset{},
+		}, nil)
 
-	env.contractService.On(
-		"RequestReceived", mock.Anything, mock.Anything,
-	).Return(&provider.ContractServiceRequestReceivedResponse{}, nil)
-	u := env.server.URL + "/negotiations/request"
+		if !autoAccept {
+			env.contractService.On(
+				"RequestReceived", mock.Anything, mock.Anything,
+			).Return(&provider.ContractServiceRequestReceivedResponse{}, nil)
+		}
+		u := env.server.URL + "/negotiations/request"
 
-	body := encode(t, shared.ContractRequestMessage{
-		Context:         shared.GetDSPContext(),
-		Type:            "dspace:ContractRequestMessage",
-		ConsumerPID:     staticConsumerPID.URN(),
-		Offer:           odrlOffer.MessageOffer,
-		CallbackAddress: callBack.String(),
-	})
-	status := fetchAndDecode[shared.ContractNegotiation](ctx, t, http.MethodPost, u, body)
-	assert.Equal(t, "dspace:ContractNegotiation", status.Type)
-	assert.Equal(t, staticConsumerPID.URN(), status.ConsumerPID)
-	assert.NotEqual(t, uuid.UUID{}, status.ProviderPID)
-	assert.Equal(t, contract.States.REQUESTED.String(), status.State)
+		body := encode(t, shared.ContractRequestMessage{
+			Context:         shared.GetDSPContext(),
+			Type:            "dspace:ContractRequestMessage",
+			ConsumerPID:     staticConsumerPID.URN(),
+			Offer:           odrlOffer.MessageOffer,
+			CallbackAddress: callBack.String(),
+		})
+		status := fetchAndDecode[shared.ContractNegotiation](ctx, t, http.MethodPost, u, body)
+		assert.Equal(t, "dspace:ContractNegotiation", status.Type)
+		assert.Equal(t, staticConsumerPID.URN(), status.ConsumerPID)
+		assert.NotEqual(t, uuid.UUID{}, status.ProviderPID)
+		assert.Equal(t, contract.States.REQUESTED.String(), status.State)
 
-	providerPID := uuid.MustParse(status.ProviderPID)
-	negotiation, err := env.store.GetContractR(ctx, providerPID, constants.DataspaceProvider)
-	assert.Nil(t, err)
-	assert.Equal(t, staticConsumerPID, negotiation.GetConsumerPID())
-	assert.Equal(t, providerPID, negotiation.GetProviderPID())
-	assert.Equal(t, contract.States.REQUESTED, negotiation.GetState())
-	assert.Equal(t, odrlOffer, negotiation.GetOffer())
-	assert.Equal(t, callBack.String(), negotiation.GetCallback().String())
+		providerPID := uuid.MustParse(status.ProviderPID)
+		negotiation, err := env.store.GetContractR(ctx, providerPID, constants.DataspaceProvider)
+		assert.Nil(t, err)
+		assert.Equal(t, staticConsumerPID, negotiation.GetConsumerPID())
+		assert.Equal(t, providerPID, negotiation.GetProviderPID())
+		assert.Equal(t, contract.States.REQUESTED, negotiation.GetState())
+		assert.Equal(t, odrlOffer, negotiation.GetOffer())
+		assert.Equal(t, callBack.String(), negotiation.GetCallback().String())
+
+		if autoAccept {
+			assert.NotNil(t, env.reconciler.e)
+			pid := env.reconciler.e.EntityID
+			assert.Equal(t, statemachine.ReconciliationContract, env.reconciler.e.Type)
+			assert.Equal(t, constants.DataspaceProvider, env.reconciler.e.Role)
+			assert.Equal(t, contract.States.OFFERED.String(), env.reconciler.e.TargetState)
+			assert.Equal(t, http.MethodPost, env.reconciler.e.Method)
+			assert.Equal(
+				t,
+				mkRequestUrl(callBack, "negotiations", staticConsumerPID.String(), "offers"),
+				env.reconciler.e.URL.String(),
+			)
+
+			var reqPayload shared.ContractOfferMessage
+			err = json.Unmarshal(env.reconciler.e.Body, &reqPayload)
+			assert.Nil(t, err)
+			assert.Equal(t, odrlOffer.MessageOffer, reqPayload.Offer)
+			assert.Equal(t, pid.URN(), reqPayload.ProviderPID)
+			assert.Equal(t, staticConsumerPID.URN(), reqPayload.ConsumerPID)
+			assert.Equal(t, mkRequestUrl(selfURL), reqPayload.CallbackAddress)
+		}
+	}
 }
 
 //nolint:dupl
 func TestNegotiationProviderRequest(t *testing.T) {
 	t.Parallel()
-	ctx, cancel, env := setupEnvironment(t)
-	defer cancel()
+	for _, autoAccept := range []bool{true, false} {
+		ctx, cancel, env := setupEnvironment(t, false)
+		defer cancel()
 
-	createNegotiation(ctx, t, env.store, contract.States.OFFERED, constants.DataspaceProvider)
+		createNegotiation(ctx, t, env.store, contract.States.OFFERED, constants.DataspaceProvider, autoAccept)
 
-	u := env.server.URL + "/negotiations/" + staticProviderPID.String() + "/request"
+		u := env.server.URL + "/negotiations/" + staticProviderPID.String() + "/request"
 
-	env.contractService.On(
-		"RequestReceived", mock.Anything, mock.Anything,
-	).Return(&provider.ContractServiceRequestReceivedResponse{}, nil)
-	body := encode(t, shared.ContractRequestMessage{
-		Context:         shared.GetDSPContext(),
-		Type:            "dspace:ContractRequestMessage",
-		ConsumerPID:     staticConsumerPID.URN(),
-		ProviderPID:     staticProviderPID.URN(),
-		Offer:           odrlOffer.MessageOffer,
-		CallbackAddress: callBack.String(),
-	})
-	status := fetchAndDecode[shared.ContractNegotiation](ctx, t, http.MethodPost, u, body)
-	assert.Equal(t, "dspace:ContractNegotiation", status.Type)
-	assert.Equal(t, staticConsumerPID.URN(), status.ConsumerPID)
-	assert.Equal(t, staticProviderPID.URN(), status.ProviderPID)
-	assert.Equal(t, contract.States.REQUESTED.String(), status.State)
+		if !autoAccept {
+			env.contractService.On(
+				"RequestReceived", mock.Anything, mock.Anything,
+			).Return(&provider.ContractServiceRequestReceivedResponse{}, nil)
+		}
+		body := encode(t, shared.ContractRequestMessage{
+			Context:         shared.GetDSPContext(),
+			Type:            "dspace:ContractRequestMessage",
+			ConsumerPID:     staticConsumerPID.URN(),
+			ProviderPID:     staticProviderPID.URN(),
+			Offer:           odrlOffer.MessageOffer,
+			CallbackAddress: callBack.String(),
+		})
+		status := fetchAndDecode[shared.ContractNegotiation](ctx, t, http.MethodPost, u, body)
+		assert.Equal(t, "dspace:ContractNegotiation", status.Type)
+		assert.Equal(t, staticConsumerPID.URN(), status.ConsumerPID)
+		assert.Equal(t, staticProviderPID.URN(), status.ProviderPID)
+		assert.Equal(t, contract.States.REQUESTED.String(), status.State)
 
-	negotiation, err := env.store.GetContractR(ctx, staticProviderPID, constants.DataspaceProvider)
-	assert.Nil(t, err)
-	assert.Equal(t, staticConsumerPID, negotiation.GetConsumerPID())
-	assert.Equal(t, staticProviderPID, negotiation.GetProviderPID())
-	assert.Equal(t, contract.States.REQUESTED, negotiation.GetState())
-	assert.Equal(t, odrlOffer, negotiation.GetOffer())
-	assert.Equal(t, callBack.String(), negotiation.GetCallback().String())
+		negotiation, err := env.store.GetContractR(ctx, staticProviderPID, constants.DataspaceProvider)
+		assert.Nil(t, err)
+		assert.Equal(t, staticConsumerPID, negotiation.GetConsumerPID())
+		assert.Equal(t, staticProviderPID, negotiation.GetProviderPID())
+		assert.Equal(t, contract.States.REQUESTED, negotiation.GetState())
+		assert.Equal(t, odrlOffer, negotiation.GetOffer())
+		assert.Equal(t, callBack.String(), negotiation.GetCallback().String())
+		if autoAccept {
+			assert.NotNil(t, env.reconciler.e)
+			assert.Equal(t, statemachine.ReconciliationContract, env.reconciler.e.Type)
+			assert.Equal(t, constants.DataspaceProvider, env.reconciler.e.Role)
+			assert.Equal(t, contract.States.AGREED.String(), env.reconciler.e.TargetState)
+			assert.Equal(t, http.MethodPost, env.reconciler.e.Method)
+			assert.Equal(
+				t,
+				mkRequestUrl(callBack, "negotiations", staticConsumerPID.String(), "agreement"),
+				env.reconciler.e.URL.String(),
+			)
+
+			var reqPayload shared.ContractAgreementMessage
+			err = json.Unmarshal(env.reconciler.e.Body, &reqPayload)
+			assert.Nil(t, err)
+			assert.Equal(t, staticProviderPID.URN(), reqPayload.ProviderPID)
+			assert.Equal(t, staticConsumerPID.URN(), reqPayload.ConsumerPID)
+		}
+	}
 }
 
 func TestNegotiationProviderEventAccepted(t *testing.T) {
 	t.Parallel()
-	ctx, cancel, env := setupEnvironment(t)
-	defer cancel()
+	for _, autoAccept := range []bool{true, false} {
+		ctx, cancel, env := setupEnvironment(t, false)
+		defer cancel()
 
-	createNegotiation(ctx, t, env.store, contract.States.OFFERED, constants.DataspaceProvider)
+		createNegotiation(ctx, t, env.store, contract.States.OFFERED, constants.DataspaceProvider, autoAccept)
 
-	u := env.server.URL + "/negotiations/" + staticProviderPID.String() + "/events"
+		u := env.server.URL + "/negotiations/" + staticProviderPID.String() + "/events"
 
-	env.contractService.EXPECT().AcceptedReceived(
-		mock.Anything, &provider.ContractServiceAcceptedReceivedRequest{
-			Pid: staticProviderPID.String(),
-		},
-	).Return(&provider.ContractServiceAcceptedReceivedResponse{}, nil)
-	body := encode(t, shared.ContractNegotiationEventMessage{
-		Context:     shared.GetDSPContext(),
-		Type:        "dspace:ContractNegotiationEventMessage",
-		ConsumerPID: staticConsumerPID.URN(),
-		ProviderPID: staticProviderPID.URN(),
-		EventType:   contract.States.ACCEPTED.String(),
-	})
-	status := fetchAndDecode[shared.ContractNegotiation](ctx, t, http.MethodPost, u, body)
-	assert.Equal(t, "dspace:ContractNegotiation", status.Type)
-	assert.Equal(t, staticConsumerPID.URN(), status.ConsumerPID)
-	assert.Equal(t, staticProviderPID.URN(), status.ProviderPID)
-	assert.Equal(t, contract.States.ACCEPTED.String(), status.State)
+		if !autoAccept {
+			env.contractService.EXPECT().AcceptedReceived(
+				mock.Anything, &provider.ContractServiceAcceptedReceivedRequest{
+					Pid: staticProviderPID.String(),
+				},
+			).Return(&provider.ContractServiceAcceptedReceivedResponse{}, nil)
+		}
+		body := encode(t, shared.ContractNegotiationEventMessage{
+			Context:     shared.GetDSPContext(),
+			Type:        "dspace:ContractNegotiationEventMessage",
+			ConsumerPID: staticConsumerPID.URN(),
+			ProviderPID: staticProviderPID.URN(),
+			EventType:   contract.States.ACCEPTED.String(),
+		})
+		status := fetchAndDecode[shared.ContractNegotiation](ctx, t, http.MethodPost, u, body)
+		assert.Equal(t, "dspace:ContractNegotiation", status.Type)
+		assert.Equal(t, staticConsumerPID.URN(), status.ConsumerPID)
+		assert.Equal(t, staticProviderPID.URN(), status.ProviderPID)
+		assert.Equal(t, contract.States.ACCEPTED.String(), status.State)
 
-	negotiation, err := env.store.GetContractR(ctx, staticProviderPID, constants.DataspaceProvider)
-	assert.Nil(t, err)
-	assert.Equal(t, staticConsumerPID, negotiation.GetConsumerPID())
-	assert.Equal(t, staticProviderPID, negotiation.GetProviderPID())
-	assert.Equal(t, contract.States.ACCEPTED, negotiation.GetState())
-	assert.Equal(t, odrlOffer, negotiation.GetOffer())
-	assert.Equal(t, callBack.String(), negotiation.GetCallback().String())
+		negotiation, err := env.store.GetContractR(ctx, staticProviderPID, constants.DataspaceProvider)
+		assert.Nil(t, err)
+		assert.Equal(t, staticConsumerPID, negotiation.GetConsumerPID())
+		assert.Equal(t, staticProviderPID, negotiation.GetProviderPID())
+		assert.Equal(t, contract.States.ACCEPTED, negotiation.GetState())
+		assert.Equal(t, odrlOffer, negotiation.GetOffer())
+		assert.Equal(t, callBack.String(), negotiation.GetCallback().String())
+
+		//nolint:dupl
+		if autoAccept {
+			assert.NotNil(t, env.reconciler.e)
+			assert.Equal(t, statemachine.ReconciliationContract, env.reconciler.e.Type)
+			assert.Equal(t, constants.DataspaceProvider, env.reconciler.e.Role)
+			assert.Equal(t, contract.States.AGREED.String(), env.reconciler.e.TargetState)
+			assert.Equal(t, http.MethodPost, env.reconciler.e.Method)
+			assert.Equal(
+				t,
+				mkRequestUrl(callBack, "negotiations", staticConsumerPID.String(), "agreement"),
+				env.reconciler.e.URL.String(),
+			)
+
+			var reqPayload shared.ContractAgreementMessage
+			err = json.Unmarshal(env.reconciler.e.Body, &reqPayload)
+			assert.Nil(t, err)
+			assert.Equal(t, staticProviderPID.URN(), reqPayload.ProviderPID)
+			assert.Equal(t, staticConsumerPID.URN(), reqPayload.ConsumerPID)
+		}
+	}
 }
 
 func TestNegotiationProviderAgreementVerification(t *testing.T) {
 	t.Parallel()
-	ctx, cancel, env := setupEnvironment(t)
-	defer cancel()
+	for _, autoAccept := range []bool{true, false} {
+		ctx, cancel, env := setupEnvironment(t, false)
+		defer cancel()
 
-	createNegotiation(ctx, t, env.store, contract.States.AGREED, constants.DataspaceProvider)
+		createNegotiation(ctx, t, env.store, contract.States.AGREED, constants.DataspaceProvider, autoAccept)
 
-	u := env.server.URL + "/negotiations/" + staticProviderPID.String() + "/agreement/verification"
+		u := env.server.URL + "/negotiations/" + staticProviderPID.String() + "/agreement/verification"
 
-	env.contractService.EXPECT().VerificationReceived(
-		mock.Anything, &provider.ContractServiceVerificationReceivedRequest{
-			Pid: staticProviderPID.String(),
-		},
-	).Return(&provider.ContractServiceVerificationReceivedResponse{}, nil)
+		if !autoAccept {
+			env.contractService.EXPECT().VerificationReceived(
+				mock.Anything, &provider.ContractServiceVerificationReceivedRequest{
+					Pid: staticProviderPID.String(),
+				},
+			).Return(&provider.ContractServiceVerificationReceivedResponse{}, nil)
+		}
 
-	body := encode(t, shared.ContractAgreementVerificationMessage{
-		Context:     shared.GetDSPContext(),
-		Type:        "dspace:ContractAgreementVerificationMessage",
-		ConsumerPID: staticConsumerPID.URN(),
-		ProviderPID: staticProviderPID.URN(),
-	})
-	status := fetchAndDecode[shared.ContractNegotiation](ctx, t, http.MethodPost, u, body)
-	assert.Equal(t, "dspace:ContractNegotiation", status.Type)
-	assert.Equal(t, staticConsumerPID.URN(), status.ConsumerPID)
-	assert.Equal(t, staticProviderPID.URN(), status.ProviderPID)
-	assert.Equal(t, contract.States.VERIFIED.String(), status.State)
+		body := encode(t, shared.ContractAgreementVerificationMessage{
+			Context:     shared.GetDSPContext(),
+			Type:        "dspace:ContractAgreementVerificationMessage",
+			ConsumerPID: staticConsumerPID.URN(),
+			ProviderPID: staticProviderPID.URN(),
+		})
+		status := fetchAndDecode[shared.ContractNegotiation](ctx, t, http.MethodPost, u, body)
+		assert.Equal(t, "dspace:ContractNegotiation", status.Type)
+		assert.Equal(t, staticConsumerPID.URN(), status.ConsumerPID)
+		assert.Equal(t, staticProviderPID.URN(), status.ProviderPID)
+		assert.Equal(t, contract.States.VERIFIED.String(), status.State)
 
-	negotiation, err := env.store.GetContractR(ctx, staticProviderPID, constants.DataspaceProvider)
-	assert.Nil(t, err)
-	assert.Equal(t, staticConsumerPID, negotiation.GetConsumerPID())
-	assert.Equal(t, staticProviderPID, negotiation.GetProviderPID())
-	assert.Equal(t, contract.States.VERIFIED, negotiation.GetState())
-	assert.Equal(t, odrlOffer, negotiation.GetOffer())
-	assert.Equal(t, callBack.String(), negotiation.GetCallback().String())
+		negotiation, err := env.store.GetContractR(ctx, staticProviderPID, constants.DataspaceProvider)
+		assert.Nil(t, err)
+		assert.Equal(t, staticConsumerPID, negotiation.GetConsumerPID())
+		assert.Equal(t, staticProviderPID, negotiation.GetProviderPID())
+		assert.Equal(t, contract.States.VERIFIED, negotiation.GetState())
+		assert.Equal(t, odrlOffer, negotiation.GetOffer())
+		assert.Equal(t, callBack.String(), negotiation.GetCallback().String())
+
+		//nolint:dupl
+		if autoAccept {
+			assert.NotNil(t, env.reconciler.e)
+			assert.Equal(t, statemachine.ReconciliationContract, env.reconciler.e.Type)
+			assert.Equal(t, constants.DataspaceProvider, env.reconciler.e.Role)
+			assert.Equal(t, contract.States.FINALIZED.String(), env.reconciler.e.TargetState)
+			assert.Equal(t, http.MethodPost, env.reconciler.e.Method)
+			assert.Equal(
+				t,
+				mkRequestUrl(callBack, "negotiations", staticConsumerPID.String(), "events"),
+				env.reconciler.e.URL.String(),
+			)
+
+			var reqPayload shared.ContractNegotiationEventMessage
+			err = json.Unmarshal(env.reconciler.e.Body, &reqPayload)
+			assert.Nil(t, err)
+			assert.Equal(t, staticProviderPID.URN(), reqPayload.ProviderPID)
+			assert.Equal(t, staticConsumerPID.URN(), reqPayload.ConsumerPID)
+			assert.Equal(t, contract.States.FINALIZED.String(), reqPayload.EventType)
+		}
+	}
 }
 
 func TestNegotiationConsumerInitialOffer(t *testing.T) {
-	ctx, cancel, env := setupEnvironment(t)
-	defer cancel()
+	t.Parallel()
+	for _, autoAccept := range []bool{true, false} {
+		ctx, cancel, env := setupEnvironment(t, autoAccept)
+		defer cancel()
 
-	u := env.server.URL + "/negotiations/offers"
+		u := env.server.URL + "/negotiations/offers"
 
-	env.contractService.On(
-		"OfferReceived", mock.Anything, mock.Anything,
-	).Return(&provider.ContractServiceOfferReceivedResponse{}, nil)
+		if !autoAccept {
+			env.contractService.On(
+				"OfferReceived", mock.Anything, mock.Anything,
+			).Return(&provider.ContractServiceOfferReceivedResponse{}, nil)
+		}
 
-	body := encode(t, shared.ContractOfferMessage{
-		Context:         shared.GetDSPContext(),
-		Type:            "dspace:ContractOfferMessage",
-		ProviderPID:     staticProviderPID.URN(),
-		Offer:           odrlOffer.MessageOffer,
-		CallbackAddress: callBack.String(),
-	})
-	status := fetchAndDecode[shared.ContractNegotiation](ctx, t, http.MethodPost, u, body)
-	assert.Equal(t, "dspace:ContractNegotiation", status.Type)
-	assert.Equal(t, staticProviderPID.URN(), status.ProviderPID)
-	assert.NotEqual(t, uuid.UUID{}, status.ConsumerPID)
-	assert.Equal(t, contract.States.OFFERED.String(), status.State)
+		body := encode(t, shared.ContractOfferMessage{
+			Context:         shared.GetDSPContext(),
+			Type:            "dspace:ContractOfferMessage",
+			ProviderPID:     staticProviderPID.URN(),
+			Offer:           odrlOffer.MessageOffer,
+			CallbackAddress: callBack.String(),
+		})
+		status := fetchAndDecode[shared.ContractNegotiation](ctx, t, http.MethodPost, u, body)
+		assert.Equal(t, "dspace:ContractNegotiation", status.Type)
+		assert.Equal(t, staticProviderPID.URN(), status.ProviderPID)
+		assert.NotEqual(t, uuid.UUID{}, status.ConsumerPID)
+		assert.Equal(t, contract.States.OFFERED.String(), status.State)
 
-	consumerPID := uuid.MustParse(status.ConsumerPID)
-	negotiation, err := env.store.GetContractR(ctx, consumerPID, constants.DataspaceConsumer)
-	assert.Nil(t, err)
-	assert.Equal(t, consumerPID, negotiation.GetConsumerPID())
-	assert.Equal(t, staticProviderPID, negotiation.GetProviderPID())
-	assert.Equal(t, contract.States.OFFERED, negotiation.GetState())
-	assert.Equal(t, odrlOffer, negotiation.GetOffer())
-	assert.Equal(t, callBack.String(), negotiation.GetCallback().String())
+		consumerPID := uuid.MustParse(status.ConsumerPID)
+		negotiation, err := env.store.GetContractR(ctx, consumerPID, constants.DataspaceConsumer)
+		assert.Nil(t, err)
+		assert.Equal(t, consumerPID, negotiation.GetConsumerPID())
+		assert.Equal(t, staticProviderPID, negotiation.GetProviderPID())
+		assert.Equal(t, contract.States.OFFERED, negotiation.GetState())
+		assert.Equal(t, odrlOffer, negotiation.GetOffer())
+		assert.Equal(t, callBack.String(), negotiation.GetCallback().String())
+
+		if autoAccept {
+			assert.NotNil(t, env.reconciler.e)
+			pid := env.reconciler.e.EntityID
+			assert.Equal(t, statemachine.ReconciliationContract, env.reconciler.e.Type)
+			assert.Equal(t, constants.DataspaceConsumer, env.reconciler.e.Role)
+			assert.Equal(t, contract.States.REQUESTED.String(), env.reconciler.e.TargetState)
+			assert.Equal(t, http.MethodPost, env.reconciler.e.Method)
+			assert.Equal(t, mkRequestUrl(
+				callBack,
+				"negotiations",
+				staticProviderPID.String(),
+				"request",
+			), env.reconciler.e.URL.String())
+
+			var reqPayload shared.ContractRequestMessage
+			err = json.Unmarshal(env.reconciler.e.Body, &reqPayload)
+			assert.Nil(t, err)
+			assert.Equal(t, odrlOffer.MessageOffer, reqPayload.Offer)
+			assert.Equal(t, pid.URN(), reqPayload.ConsumerPID)
+			assert.Equal(t, staticProviderPID.URN(), reqPayload.ProviderPID)
+			assert.Equal(t, mkRequestUrl(selfURL, "callback"), reqPayload.CallbackAddress)
+		}
+	}
 }
 
 //nolint:dupl
 func TestNegotiationConsumerOffer(t *testing.T) {
 	t.Parallel()
-	ctx, cancel, env := setupEnvironment(t)
-	defer cancel()
+	for _, autoAccept := range []bool{true, false} {
+		ctx, cancel, env := setupEnvironment(t, false)
+		defer cancel()
 
-	createNegotiation(ctx, t, env.store, contract.States.REQUESTED, constants.DataspaceConsumer)
+		createNegotiation(ctx, t, env.store, contract.States.REQUESTED, constants.DataspaceConsumer, autoAccept)
 
-	u := env.server.URL + "/callback/negotiations/" + staticConsumerPID.String() + "/offers"
+		u := env.server.URL + "/callback/negotiations/" + staticConsumerPID.String() + "/offers"
 
-	env.contractService.On(
-		"OfferReceived", mock.Anything, mock.Anything,
-	).Return(&provider.ContractServiceOfferReceivedResponse{}, nil)
+		if !autoAccept {
+			env.contractService.On(
+				"OfferReceived", mock.Anything, mock.Anything,
+			).Return(&provider.ContractServiceOfferReceivedResponse{}, nil)
+		}
 
-	body := encode(t, shared.ContractOfferMessage{
-		Context:         shared.GetDSPContext(),
-		Type:            "dspace:ContractOfferMessage",
-		ConsumerPID:     staticConsumerPID.URN(),
-		ProviderPID:     staticProviderPID.URN(),
-		Offer:           odrlOffer.MessageOffer,
-		CallbackAddress: callBack.String(),
-	})
-	status := fetchAndDecode[shared.ContractNegotiation](ctx, t, http.MethodPost, u, body)
-	assert.Equal(t, "dspace:ContractNegotiation", status.Type)
-	assert.Equal(t, staticConsumerPID.URN(), status.ConsumerPID)
-	assert.Equal(t, staticProviderPID.URN(), status.ProviderPID)
-	assert.Equal(t, contract.States.OFFERED.String(), status.State)
-
-	negotiation, err := env.store.GetContractR(ctx, staticConsumerPID, constants.DataspaceConsumer)
-	assert.Nil(t, err)
-	assert.Equal(t, staticConsumerPID, negotiation.GetConsumerPID())
-	assert.Equal(t, staticProviderPID, negotiation.GetProviderPID())
-	assert.Equal(t, contract.States.OFFERED, negotiation.GetState())
-	assert.Equal(t, odrlOffer, negotiation.GetOffer())
-	assert.Equal(t, callBack.String(), negotiation.GetCallback().String())
-}
-
-func TestNegotiationConsumerAgreement(t *testing.T) {
-	t.Parallel()
-	ctx, cancel, env := setupEnvironment(t)
-	defer cancel()
-
-	for _, s := range []contract.State{contract.States.REQUESTED, contract.States.ACCEPTED} {
-		createNegotiation(ctx, t, env.store, s, constants.DataspaceConsumer)
-
-		env.contractService.EXPECT().AgreementReceived(
-			mock.Anything, &provider.ContractServiceAgreementReceivedRequest{
-				Pid: staticConsumerPID.String(),
-			},
-		).Return(&provider.ContractServiceAgreementReceivedResponse{}, nil)
-
-		u := env.server.URL + "/callback/negotiations/" + staticConsumerPID.String() + "/agreement"
-
-		body := encode(t, shared.ContractAgreementMessage{
+		body := encode(t, shared.ContractOfferMessage{
 			Context:         shared.GetDSPContext(),
-			Type:            "dspace:ContractAgreementMessage",
+			Type:            "dspace:ContractOfferMessage",
 			ConsumerPID:     staticConsumerPID.URN(),
 			ProviderPID:     staticProviderPID.URN(),
-			Agreement:       odrlAgreement,
+			Offer:           odrlOffer.MessageOffer,
 			CallbackAddress: callBack.String(),
+		})
+		status := fetchAndDecode[shared.ContractNegotiation](ctx, t, http.MethodPost, u, body)
+		assert.Equal(t, "dspace:ContractNegotiation", status.Type)
+		assert.Equal(t, staticConsumerPID.URN(), status.ConsumerPID)
+		assert.Equal(t, staticProviderPID.URN(), status.ProviderPID)
+		assert.Equal(t, contract.States.OFFERED.String(), status.State)
+
+		negotiation, err := env.store.GetContractR(ctx, staticConsumerPID, constants.DataspaceConsumer)
+		assert.Nil(t, err)
+		assert.Equal(t, staticConsumerPID, negotiation.GetConsumerPID())
+		assert.Equal(t, staticProviderPID, negotiation.GetProviderPID())
+		assert.Equal(t, contract.States.OFFERED, negotiation.GetState())
+		assert.Equal(t, odrlOffer, negotiation.GetOffer())
+		assert.Equal(t, callBack.String(), negotiation.GetCallback().String())
+
+		if autoAccept {
+			assert.NotNil(t, env.reconciler.e)
+			assert.Equal(t, statemachine.ReconciliationContract, env.reconciler.e.Type)
+			assert.Equal(t, constants.DataspaceConsumer, env.reconciler.e.Role)
+			assert.Equal(t, contract.States.ACCEPTED.String(), env.reconciler.e.TargetState)
+			assert.Equal(t, http.MethodPost, env.reconciler.e.Method)
+			assert.Equal(t, mkRequestUrl(
+				callBack,
+				"negotiations",
+				staticProviderPID.String(),
+				"events",
+			), env.reconciler.e.URL.String())
+
+			var reqPayload shared.ContractNegotiationEventMessage
+			err = json.Unmarshal(env.reconciler.e.Body, &reqPayload)
+			assert.Nil(t, err)
+			assert.Equal(t, staticConsumerPID.URN(), reqPayload.ConsumerPID)
+			assert.Equal(t, staticProviderPID.URN(), reqPayload.ProviderPID)
+			assert.Equal(t, contract.States.ACCEPTED.String(), reqPayload.EventType)
+		}
+	}
+}
+
+//nolint:funlen
+func TestNegotiationConsumerAgreement(t *testing.T) {
+	t.Parallel()
+	for _, autoAccept := range []bool{true, false} {
+		ctx, cancel, env := setupEnvironment(t, false)
+		defer cancel()
+
+		for _, s := range []contract.State{contract.States.REQUESTED, contract.States.ACCEPTED} {
+			createNegotiation(ctx, t, env.store, s, constants.DataspaceConsumer, autoAccept)
+
+			if !autoAccept {
+				env.contractService.EXPECT().AgreementReceived(
+					mock.Anything, &provider.ContractServiceAgreementReceivedRequest{
+						Pid: staticConsumerPID.String(),
+					},
+				).Return(&provider.ContractServiceAgreementReceivedResponse{}, nil)
+			}
+
+			u := env.server.URL + "/callback/negotiations/" + staticConsumerPID.String() + "/agreement"
+
+			body := encode(t, shared.ContractAgreementMessage{
+				Context:         shared.GetDSPContext(),
+				Type:            "dspace:ContractAgreementMessage",
+				ConsumerPID:     staticConsumerPID.URN(),
+				ProviderPID:     staticProviderPID.URN(),
+				Agreement:       odrlAgreement,
+				CallbackAddress: callBack.String(),
+			})
+
+			status := fetchAndDecode[shared.ContractNegotiation](ctx, t, http.MethodPost, u, body)
+			assert.Equal(t, "dspace:ContractNegotiation", status.Type)
+			assert.Equal(t, staticConsumerPID.URN(), status.ConsumerPID)
+			assert.Equal(t, staticProviderPID.URN(), status.ProviderPID)
+			assert.Equal(t, contract.States.AGREED.String(), status.State)
+
+			negotiation, err := env.store.GetContractR(ctx, staticConsumerPID, constants.DataspaceConsumer)
+			assert.Nil(t, err)
+			assert.Equal(t, staticConsumerPID, negotiation.GetConsumerPID())
+			assert.Equal(t, staticProviderPID, negotiation.GetProviderPID())
+			assert.Equal(t, contract.States.AGREED, negotiation.GetState())
+			assert.Equal(t, odrlOffer, negotiation.GetOffer())
+			assert.Equal(t, &odrlAgreement, negotiation.GetAgreement())
+			assert.Equal(t, callBack.String(), negotiation.GetCallback().String())
+
+			if autoAccept {
+				assert.NotNil(t, env.reconciler.e)
+				assert.Equal(t, statemachine.ReconciliationContract, env.reconciler.e.Type)
+				assert.Equal(t, constants.DataspaceConsumer, env.reconciler.e.Role)
+				assert.Equal(t, contract.States.VERIFIED.String(), env.reconciler.e.TargetState)
+				assert.Equal(t, http.MethodPost, env.reconciler.e.Method)
+				assert.Equal(t, mkRequestUrl(
+					callBack,
+					"negotiations",
+					staticProviderPID.String(),
+					"agreement",
+					"verification",
+				), env.reconciler.e.URL.String())
+
+				var reqPayload shared.ContractAgreementVerificationMessage
+				err = json.Unmarshal(env.reconciler.e.Body, &reqPayload)
+				assert.Nil(t, err)
+				assert.Equal(t, staticConsumerPID.URN(), reqPayload.ConsumerPID)
+				assert.Equal(t, staticProviderPID.URN(), reqPayload.ProviderPID)
+			}
+		}
+	}
+}
+
+func TestNegotiationConsumerEventFinalized(t *testing.T) {
+	t.Parallel()
+	for _, autoAccept := range []bool{true, false} {
+		ctx, cancel, env := setupEnvironment(t, false)
+		defer cancel()
+
+		if !autoAccept {
+			env.contractService.EXPECT().FinalizationReceived(
+				mock.Anything, &provider.ContractServiceFinalizationReceivedRequest{
+					Pid: staticConsumerPID.String(),
+				},
+			).Return(&provider.ContractServiceFinalizationReceivedResponse{}, nil)
+		}
+		createNegotiation(ctx, t, env.store, contract.States.VERIFIED, constants.DataspaceConsumer, autoAccept)
+
+		u := env.server.URL + "/callback/negotiations/" + staticConsumerPID.String() + "/events"
+
+		body := encode(t, shared.ContractNegotiationEventMessage{
+			Context:     shared.GetDSPContext(),
+			Type:        "dspace:ContractNegotiationEventMessage",
+			ConsumerPID: staticConsumerPID.URN(),
+			ProviderPID: staticProviderPID.URN(),
+			EventType:   contract.States.FINALIZED.String(),
 		})
 
 		status := fetchAndDecode[shared.ContractNegotiation](ctx, t, http.MethodPost, u, body)
 		assert.Equal(t, "dspace:ContractNegotiation", status.Type)
 		assert.Equal(t, staticConsumerPID.URN(), status.ConsumerPID)
 		assert.Equal(t, staticProviderPID.URN(), status.ProviderPID)
-		assert.Equal(t, contract.States.AGREED.String(), status.State)
+		assert.Equal(t, contract.States.FINALIZED.String(), status.State)
 
 		negotiation, err := env.store.GetContractR(ctx, staticConsumerPID, constants.DataspaceConsumer)
 		assert.Nil(t, err)
 		assert.Equal(t, staticConsumerPID, negotiation.GetConsumerPID())
 		assert.Equal(t, staticProviderPID, negotiation.GetProviderPID())
-		assert.Equal(t, contract.States.AGREED, negotiation.GetState())
+		assert.Equal(t, contract.States.FINALIZED, negotiation.GetState())
 		assert.Equal(t, odrlOffer, negotiation.GetOffer())
-		assert.Equal(t, &odrlAgreement, negotiation.GetAgreement())
 		assert.Equal(t, callBack.String(), negotiation.GetCallback().String())
 	}
-}
-
-func TestNegotiationConsumerEventFinalized(t *testing.T) {
-	t.Parallel()
-	ctx, cancel, env := setupEnvironment(t)
-	defer cancel()
-
-	env.contractService.EXPECT().FinalizationReceived(
-		mock.Anything, &provider.ContractServiceFinalizationReceivedRequest{
-			Pid: staticConsumerPID.String(),
-		},
-	).Return(&provider.ContractServiceFinalizationReceivedResponse{}, nil)
-	createNegotiation(ctx, t, env.store, contract.States.VERIFIED, constants.DataspaceConsumer)
-
-	u := env.server.URL + "/callback/negotiations/" + staticConsumerPID.String() + "/events"
-
-	body := encode(t, shared.ContractNegotiationEventMessage{
-		Context:     shared.GetDSPContext(),
-		Type:        "dspace:ContractNegotiationEventMessage",
-		ConsumerPID: staticConsumerPID.URN(),
-		ProviderPID: staticProviderPID.URN(),
-		EventType:   contract.States.FINALIZED.String(),
-	})
-
-	status := fetchAndDecode[shared.ContractNegotiation](ctx, t, http.MethodPost, u, body)
-	assert.Equal(t, "dspace:ContractNegotiation", status.Type)
-	assert.Equal(t, staticConsumerPID.URN(), status.ConsumerPID)
-	assert.Equal(t, staticProviderPID.URN(), status.ProviderPID)
-	assert.Equal(t, contract.States.FINALIZED.String(), status.State)
-
-	negotiation, err := env.store.GetContractR(ctx, staticConsumerPID, constants.DataspaceConsumer)
-	assert.Nil(t, err)
-	assert.Equal(t, staticConsumerPID, negotiation.GetConsumerPID())
-	assert.Equal(t, staticProviderPID, negotiation.GetProviderPID())
-	assert.Equal(t, contract.States.FINALIZED, negotiation.GetState())
-	assert.Equal(t, odrlOffer, negotiation.GetOffer())
-	assert.Equal(t, callBack.String(), negotiation.GetCallback().String())
 }
 
 func TestNegotiationTermination(t *testing.T) {
 	t.Parallel()
 
-	for _, r := range []constants.DataspaceRole{constants.DataspaceConsumer, constants.DataspaceProvider} {
-		for _, s := range []contract.State{
-			contract.States.REQUESTED,
-			contract.States.OFFERED,
-			contract.States.ACCEPTED,
-			contract.States.AGREED,
-			contract.States.VERIFIED,
-		} {
-			ctx, cancel, env := setupEnvironment(t)
-			defer cancel()
-			u := env.server.URL + "/negotiations/" + pidMap[r].String() + "/termination"
-			createNegotiation(ctx, t, env.store, s, r)
-			pid := staticConsumerPID.String()
-			if r == constants.DataspaceProvider {
-				pid = staticProviderPID.String()
+	for _, autoAccept := range []bool{true, false} {
+		for _, r := range []constants.DataspaceRole{constants.DataspaceConsumer, constants.DataspaceProvider} {
+			for _, s := range []contract.State{
+				contract.States.REQUESTED,
+				contract.States.OFFERED,
+				contract.States.ACCEPTED,
+				contract.States.AGREED,
+				contract.States.VERIFIED,
+			} {
+				ctx, cancel, env := setupEnvironment(t, false)
+				defer cancel()
+				u := env.server.URL + "/negotiations/" + pidMap[r].String() + "/termination"
+				createNegotiation(ctx, t, env.store, s, r, autoAccept)
+				pid := staticConsumerPID.String()
+				if r == constants.DataspaceProvider {
+					pid = staticProviderPID.String()
+				}
+
+				if !autoAccept {
+					env.contractService.EXPECT().TerminationReceived(
+						mock.Anything, &provider.ContractServiceTerminationReceivedRequest{
+							Pid:    pid,
+							Code:   "some code",
+							Reason: []string{"test"},
+						},
+					).Return(&provider.ContractServiceTerminationReceivedResponse{}, nil)
+				}
+
+				body := encode(t, shared.ContractNegotiationTerminationMessage{
+					Context:     shared.GetDSPContext(),
+					Type:        "dspace:ContractNegotiationTerminationMessage",
+					ConsumerPID: staticConsumerPID.URN(),
+					ProviderPID: staticProviderPID.URN(),
+					Code:        "some code",
+					Reason: []shared.Multilanguage{{
+						Value:    "test",
+						Language: "en",
+					}},
+				})
+				status := fetchAndDecode[shared.ContractNegotiation](ctx, t, http.MethodPost, u, body)
+				assert.Equal(t, "dspace:ContractNegotiation", status.Type)
+				assert.Equal(t, staticConsumerPID.URN(), status.ConsumerPID)
+				assert.Equal(t, staticProviderPID.URN(), status.ProviderPID)
+				assert.Equal(t, contract.States.TERMINATED.String(), status.State)
+
+				negotiation, err := env.store.GetContractR(ctx, pidMap[r], r)
+				assert.Nil(t, err)
+				assert.Equal(t, staticConsumerPID, negotiation.GetConsumerPID())
+				assert.Equal(t, staticProviderPID, negotiation.GetProviderPID())
+				assert.Equal(t, contract.States.TERMINATED, negotiation.GetState())
+				assert.Equal(t, odrlOffer, negotiation.GetOffer())
+				assert.Equal(t, callBack.String(), negotiation.GetCallback().String())
 			}
-			env.contractService.EXPECT().TerminationReceived(
-				mock.Anything, &provider.ContractServiceTerminationReceivedRequest{
-					Pid:    pid,
-					Code:   "some code",
-					Reason: []string{"test"},
-				},
-			).Return(&provider.ContractServiceTerminationReceivedResponse{}, nil)
-
-			body := encode(t, shared.ContractNegotiationTerminationMessage{
-				Context:     shared.GetDSPContext(),
-				Type:        "dspace:ContractNegotiationTerminationMessage",
-				ConsumerPID: staticConsumerPID.URN(),
-				ProviderPID: staticProviderPID.URN(),
-				Code:        "some code",
-				Reason: []shared.Multilanguage{{
-					Value:    "test",
-					Language: "en",
-				}},
-			})
-			status := fetchAndDecode[shared.ContractNegotiation](ctx, t, http.MethodPost, u, body)
-			assert.Equal(t, "dspace:ContractNegotiation", status.Type)
-			assert.Equal(t, staticConsumerPID.URN(), status.ConsumerPID)
-			assert.Equal(t, staticProviderPID.URN(), status.ProviderPID)
-			assert.Equal(t, contract.States.TERMINATED.String(), status.State)
-
-			negotiation, err := env.store.GetContractR(ctx, pidMap[r], r)
-			assert.Nil(t, err)
-			assert.Equal(t, staticConsumerPID, negotiation.GetConsumerPID())
-			assert.Equal(t, staticProviderPID, negotiation.GetProviderPID())
-			assert.Equal(t, contract.States.TERMINATED, negotiation.GetState())
-			assert.Equal(t, odrlOffer, negotiation.GetOffer())
-			assert.Equal(t, callBack.String(), negotiation.GetCallback().String())
 		}
 	}
 }

--- a/dsp/control/contracts_test.go
+++ b/dsp/control/contracts_test.go
@@ -147,6 +147,7 @@ func createNegotiation(
 		callBack,
 		selfURL,
 		role,
+		false,
 	)
 	err := store.PutContract(ctx, neg)
 	assert.Nil(t, err)

--- a/dsp/statemachine/contract_statemachine_test.go
+++ b/dsp/statemachine/contract_statemachine_test.go
@@ -111,7 +111,7 @@ func TestTermination(t *testing.T) {
 			providerPID := uuid.New()
 			negotiation := contract.New(
 				providerPID, consumerPID,
-				state, offer, providerCallback, consumerCallback, role)
+				state, offer, providerCallback, consumerCallback, role, false)
 			pid := consumerPID
 			if role == constants.DataspaceProvider {
 				pid = providerPID

--- a/dsp/statemachine/transfer_messages.go
+++ b/dsp/statemachine/transfer_messages.go
@@ -43,16 +43,22 @@ func makeTransferRequestFunction(
 	} else {
 		id = t.GetProviderPID()
 	}
-	return makeRequestFunction(
-		ctx,
-		cu,
-		reqBody,
-		id,
-		t.GetRole(),
-		destinationState.String(),
-		ReconciliationTransferRequest,
-		reconciler,
-	)
+	return func() {
+		f := makeRequestFunction(
+			ctx,
+			cu,
+			reqBody,
+			id,
+			t.GetRole(),
+			destinationState.String(),
+			ReconciliationTransferRequest,
+			reconciler,
+		)
+		err := f()
+		if err != nil {
+			panic(err.Error())
+		}
+	}
 }
 
 func sendTransferRequest(ctx context.Context, tr *TransferRequestNegotiationInitial) (func(), error) {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/dgraph-io/badger/v4 v4.4.0
 	github.com/fatih/color v1.17.0
 	github.com/gammazero/deque v1.0.0
-	github.com/go-dataspace/run-dsrpc v0.0.6-alpha2
+	github.com/go-dataspace/run-dsrpc v0.0.7-alpha2
 	github.com/go-playground/validator/v10 v10.22.0
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/go-dataspace/run-dsrpc v0.0.5-alpha2 h1:NH5QlZjCjx5OBoVQo7rSZb89lKj9N
 github.com/go-dataspace/run-dsrpc v0.0.5-alpha2/go.mod h1:GS4hV6keaQWCn9KTwMqNgzOdIgPnJ/+NSHSvgrsLbTE=
 github.com/go-dataspace/run-dsrpc v0.0.6-alpha2 h1:pD9KnxpHLtRcBIuys0xWpvhxer92WrOgsEJfUYTYSZo=
 github.com/go-dataspace/run-dsrpc v0.0.6-alpha2/go.mod h1:ietl2RJlnxlorgwb4XBwnJyTSL6GqcClOqEBtEETQh4=
+github.com/go-dataspace/run-dsrpc v0.0.7-alpha2 h1:XaS1plRrFhr+go2C7L+p/rrvaqTDSUbzZQwaDEXomFs=
+github.com/go-dataspace/run-dsrpc v0.0.7-alpha2/go.mod h1:ietl2RJlnxlorgwb4XBwnJyTSL6GqcClOqEBtEETQh4=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=


### PR DESCRIPTION
This allows RUN-DSP to be configured without a contract service,
or for a contract service to set a negotiation to "auto accept".

When RUN-DSP handles a negotiation that's set to auto accept, it will
automatically accept and continue to the next step of the negotiation.
Removing the need for any input from the contract service from that
point forward.